### PR TITLE
Changed React import to * from React

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ yarn add react-sketch-canvas
 Common usage example
 
 ```javascript
-import React from 'react';
+import * as React from 'react';
 import { ReactSketchCanvas } from 'react-sketch-canvas';
 
 const styles = {
@@ -79,7 +79,7 @@ const Canvas = () => {
 To export Data URL of your sketch use ref
 
 ```javascript
-import React from "react";
+import * as React from "react";
 import { ReactSketchCanvas } from "react-sketch-canvas";
 
 const styles = {

--- a/libs/react-sketch-canvas/src/lib/Canvas/index.tsx
+++ b/libs/react-sketch-canvas/src/lib/Canvas/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import Paths from '../Paths';
 import { CanvasPath, ExportImageType, Point } from '../types';
 

--- a/libs/react-sketch-canvas/src/lib/Paths/index.tsx
+++ b/libs/react-sketch-canvas/src/lib/Paths/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { CanvasPath, Point } from '../types';
 
 const svgPath = (

--- a/libs/react-sketch-canvas/src/lib/ReactSketchCanvas/index.tsx
+++ b/libs/react-sketch-canvas/src/lib/ReactSketchCanvas/index.tsx
@@ -1,5 +1,5 @@
 import { produce } from 'immer';
-import React from 'react';
+import * as React from 'react';
 import { Canvas } from '../Canvas';
 import { CanvasPath, ExportImageType, Point } from '../types';
 

--- a/libs/react-sketch-canvas/src/stories/0.demo.stories.mdx
+++ b/libs/react-sketch-canvas/src/stories/0.demo.stories.mdx
@@ -44,7 +44,7 @@ yarn add react-sketch-canvas
 Common usage example
 
 ```javascript
-import React from 'react';
+import * as React from 'react';
 import { ReactSketchCanvas } from 'react-sketch-canvas';
 
 const styles = {
@@ -68,7 +68,7 @@ const Canvas = () => {
 To export Data URL of your sketch use ref
 
 ```javascript
-import React from "react";
+import * as React from "react";
 import { ReactSketchCanvas } from "react-sketch-canvas";
 
 const styles = {

--- a/libs/react-sketch-canvas/src/stories/1.demo.stories.tsx
+++ b/libs/react-sketch-canvas/src/stories/1.demo.stories.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 
 import { Meta, Story } from '@storybook/react';
-import React from 'react';
+import * as React from 'react';
 import { CanvasPath, ReactSketchCanvas, ReactSketchCanvasProps } from '..';
 import './demo.stories.css';
 


### PR DESCRIPTION
Hi!

When I tried the examples, I got the error

TS2786: 'ReactSketchCanvas' cannot be used as a JSX component.
  Its instance type 'ReactSketchCanvas' is not a valid JSX element.
Type 'ReactSketchCanvas' is missing the following properties from type 'ElementClass': context, setState, forceUpdate, props, and 2 more

I am using

typescript 4.3.5
React 17.0.2
Node 16.5.0

With these small changes, the errors are gone.