### PR TITLE
Allow custom styling for the SVG Element

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ const Canvas = class extends React.Component {
 | onChange                           | PropTypes.func    |                       | Returns the current sketch path in `CanvasPath` type on every path change                           |
 | onStroke                           | PropTypes.func    |                       | Returns the the last stroke path and whether it is an eraser stroke on every pointer up event       |
 | style                              | PropTypes.object  | false                 | Add CSS styling as CSS-in-JS object                                                                 |
+| svgStyle                           | PropTypes.object  | {}                    | Add CSS styling as CSS-in-JS object for the SVG                                                     |
 | withTimestamp                      | PropTypes.bool    | false                 | Add timestamp to individual strokes for measuring sketching time                                    |
 
 Set SVG background using CSS [background][css-bg] value

--- a/cypress/fixtures/props.json
+++ b/cypress/fixtures/props.json
@@ -10,6 +10,7 @@
   "strokeColor": "#000000",
   "canvasColor": "#FFFFFF",
   "style": { "borderRight": "1px solid #CCC" },
+  "svgStyle": {},
   "exportWithBackgroundImage": true,
   "withTimestamp": true,
   "allowOnlyPointerType": "all"

--- a/cypress/integration/props.spec.ts
+++ b/cypress/integration/props.spec.ts
@@ -376,7 +376,7 @@ it('should update style', () => {
       Object.keys(defaultProps.style).map(Cypress._.kebabCase)
     );
 
-  cy.findByRole('textbox', { name: /style/i })
+  cy.findByRole('textbox', { name: 'style', exact: true })
     .clear()
     .type(JSON.stringify(updatedStyle), {
       parseSpecialCharSequences: false,
@@ -391,6 +391,27 @@ it('should update style', () => {
       Object.keys(defaultProps.style).map(Cypress._.kebabCase)
     )
     .and('have.any.keys', Object.keys(updatedStyle).map(Cypress._.kebabCase));
+});
+
+it('should update SVG style', () => {
+  const updatedStyle = {
+    background: 'red',
+  };
+
+  cy.findByRole('textbox', { name: 'SVG style' })
+    .clear()
+    .type(JSON.stringify(updatedStyle), {
+      parseSpecialCharSequences: false,
+      delay: 0,
+    });
+
+  cy.getCanvas()
+    .find('svg')
+    .should('have.attr', 'style')
+    .CssStyleToObject()
+    .and(
+      'have.any.keys', Object.keys(updatedStyle).map(Cypress._.kebabCase)
+    );
 });
 
 describe('onStroke', () => {

--- a/cypress/integration/props.spec.ts
+++ b/cypress/integration/props.spec.ts
@@ -409,9 +409,7 @@ it('should update SVG style', () => {
     .find('svg')
     .should('have.attr', 'style')
     .CssStyleToObject()
-    .and(
-      'have.any.keys', Object.keys(updatedStyle).map(Cypress._.kebabCase)
-    );
+    .and('have.any.keys', Object.keys(updatedStyle).map(Cypress._.kebabCase));
 });
 
 describe('onStroke', () => {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -69,6 +69,7 @@ function App() {
     strokeColor: '#000000',
     canvasColor: '#FFFFFF',
     style: { borderRight: '1px solid #CCC' },
+    svgStyle: {},
     exportWithBackgroundImage: true,
     withTimestamp: true,
     allowOnlyPointerType: 'all',
@@ -495,6 +496,30 @@ function App() {
                   }}
                   rows={5}
                   defaultValue={JSON.stringify(canvasProps.style, null, 2)}
+                />
+              </div>
+              <div className="p-2 col-10">
+                <label htmlFor="svg-style" className="form-label">
+                  SVG style
+                </label>
+                <textarea
+                  id="svg-style"
+                  className="dataURICode col-12"
+                  onChange={(event) => {
+                    try {
+                      const svgStyle = JSON.parse(event.target.value);
+                      setCanvasProps(
+                        (prevCanvasProps: Partial<ReactSketchCanvasProps>) => ({
+                          ...prevCanvasProps,
+                          svgStyle: svgStyle,
+                        })
+                      );
+                    } catch {
+                      return;
+                    }
+                  }}
+                  rows={5}
+                  defaultValue={JSON.stringify(canvasProps.svgStyle, null, 2)}
                 />
               </div>
               <div className="p-2 col-10">

--- a/src/Canvas/index.tsx
+++ b/src/Canvas/index.tsx
@@ -45,6 +45,7 @@ export interface CanvasProps {
   preserveBackgroundImageAspectRatio: string;
   allowOnlyPointerType: string;
   style: React.CSSProperties;
+  svgStyle: React.CSSProperties;
 }
 
 export interface CanvasRef {
@@ -72,6 +73,7 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
       border: '0.0625rem solid #9c9c9c',
       borderRadius: '0.25rem',
     },
+    svgStyle = {},
   } = props;
 
   const canvasRef = React.useRef<HTMLDivElement>(null);
@@ -290,6 +292,7 @@ release drawing even when point goes out of canvas */
         style={{
           width: '100%',
           height: '100%',
+          ...svgStyle,
         }}
         id={id}
       >

--- a/src/ReactSketchCanvas/index.tsx
+++ b/src/ReactSketchCanvas/index.tsx
@@ -21,6 +21,7 @@ export interface ReactSketchCanvasProps {
   onChange?: (updatedPaths: CanvasPath[]) => void;
   onStroke?: (path: CanvasPath, isEraser: boolean) => void;
   style?: React.CSSProperties;
+  svgStyle?: React.CSSProperties;
   withTimestamp?: boolean;
 }
 
@@ -58,6 +59,7 @@ export const ReactSketchCanvas = React.forwardRef<
       border: '0.0625rem solid #9c9c9c',
       borderRadius: '0.25rem',
     },
+    svgStyle = {},
     onChange = (_paths: CanvasPath[]): void => {},
     onStroke = (_path: CanvasPath, _isEraser: boolean): void => {},
     withTimestamp = false,
@@ -264,6 +266,7 @@ export const ReactSketchCanvas = React.forwardRef<
       preserveBackgroundImageAspectRatio={preserveBackgroundImageAspectRatio}
       allowOnlyPointerType={allowOnlyPointerType}
       style={style}
+      svgStyle={svgStyle}
       paths={currentPaths}
       isDrawing={isDrawing}
       onPointerDown={handlePointerDown}


### PR DESCRIPTION
This allows us to be able to customize the SVG, meaning we can use a background image with all the CSS properties of background properly, and still be able to export an SVG with that background (we wouldn't be able to do that by having on the `style` since it wouldn't apply to the export).

might solve https://github.com/vinothpandian/react-sketch-canvas/issues/58 too (that's the main reason I made this)