### PR TITLE
Only set mask attribute if the corresponding mask exists

### DIFF
--- a/packages/react-sketch-canvas/src/Canvas/index.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/index.tsx
@@ -391,7 +391,7 @@ release drawing even when point goes out of canvas */
           <g
             id={`${id}__stroke-group-${i}`}
             key={`${id}__stroke-group-${i}`}
-            mask={`url(#${id}__eraser-mask-${i})`}
+            mask={`${eraserPaths[i] && "url(#${id}__eraser-mask-${i})"}`}
           >
             <Paths id={`${id}__stroke-group-${i}__paths`} paths={pathGroup} />
           </g>

--- a/packages/react-sketch-canvas/src/Canvas/index.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/index.tsx
@@ -391,7 +391,7 @@ release drawing even when point goes out of canvas */
           <g
             id={`${id}__stroke-group-${i}`}
             key={`${id}__stroke-group-${i}`}
-            mask={`${eraserPaths[i] && "url(#${id}__eraser-mask-${i})"}`}
+            mask={`${eraserPaths[i] && `url(#${id}__eraser-mask-${i})`}`}
           >
             <Paths id={`${id}__stroke-group-${i}__paths`} paths={pathGroup} />
           </g>


### PR DESCRIPTION
Without this PR it's possible to have path groups that link to masks that don't exist because `eraserPaths` might be empty.

The linking of non-existent paths is what was breaking things on Firefox for me. With this PR, things seem to work great on Firefox.