### PR TITLE
fix: remove invalid mask attribute from stroke groups without eraser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ packages/tests/.nyc_output/
 packages/tests/coverage/
 packages/tests/cypress/downloads/
 .idea/
-.turbo/cookies/
+.turbo/
 /apps/docs/src/content/docs/api/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 ## Demo Development Server
 
-- Run `pnpm start` to start the development server.
+- Run `pnpm dev` to start the development server.
 - Open `http://localhost:4321/react-sketch-canvas/` in your browser.
 
 ## Running Tests

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -18,7 +18,6 @@ hero:
 
 import { Card, CardGrid } from "@astrojs/starlight/components";
 import { HomePageDemo } from "../../components/HomePageDemo";
-import { Link } from "@astrojs/check";
 
 <HomePageDemo client:load />
 

--- a/packages/react-sketch-canvas/src/Canvas/index.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/index.tsx
@@ -406,7 +406,9 @@ release drawing even when point goes out of canvas */
           <g
             id={`${id}__stroke-group-${i}`}
             key={`${id}__stroke-group-${i}`}
-            mask={`${eraserPaths[i] && `url(#${id}__eraser-mask-${i})`}`}
+            {...(eraserPaths[i]
+              ? { mask: `url(#${id}__eraser-mask-${i})` }
+              : {})}
           >
             <Paths id={`${id}__stroke-group-${i}__paths`} paths={pathGroup} />
           </g>

--- a/packages/tests/src/actions/erase.spec.tsx
+++ b/packages/tests/src/actions/erase.spec.tsx
@@ -103,6 +103,75 @@ test.describe("eraser", () => {
     );
   });
 
+  test("should not set mask attribute on stroke group when no eraser paths exist", async ({
+    mount,
+  }) => {
+    const canvasId = "rsc";
+
+    const component = await mount(<ReactSketchCanvas id={canvasId} />);
+
+    const { firstStrokeGroupId } = getCanvasIds(canvasId);
+
+    const canvas = component.locator(`#${canvasId}`);
+
+    // Draw a stroke without using the eraser
+    await drawLine(canvas, {
+      length: 50,
+      originX: 0,
+      originY: 10,
+    });
+
+    // The stroke group should not have a mask attribute when there are no eraser paths
+    await expect(canvas.locator(firstStrokeGroupId)).not.toHaveAttribute(
+      "mask",
+    );
+
+    // Verify the stroke path exists
+    await expect(
+      canvas.locator(firstStrokeGroupId).locator("path"),
+    ).toHaveCount(1);
+  });
+
+  test("should not set mask attribute on last stroke group after erasing", async ({
+    mount,
+  }) => {
+    const canvasId = "rsc";
+    const eraserButtonId = "eraser-button";
+    const penButtonId = "pen-button";
+
+    const component = await mount(
+      <WithEraserButton
+        id={canvasId}
+        eraserButtonId={eraserButtonId}
+        penButtonId={penButtonId}
+      />,
+    );
+
+    const { firstStrokeGroupId, secondStrokeGroupId } = getCanvasIds(canvasId);
+
+    const canvas = component.locator(`#${canvasId}`);
+    const eraserButton = component.locator(`#${eraserButtonId}`);
+    const penButton = component.locator(`#${penButtonId}`);
+
+    // Draw → Erase → Draw (creates 2 stroke groups, only first has a mask)
+    await drawLine(canvas, { length: 50, originX: 0, originY: 10 });
+    await eraserButton.click();
+    await drawLine(canvas, { length: 10, originX: 0, originY: 10 });
+    await penButton.click();
+    await drawLine(canvas, { length: 50, originX: 10, originY: 20 });
+
+    // First stroke group should have the eraser mask
+    await expect(canvas.locator(firstStrokeGroupId)).toHaveAttribute(
+      "mask",
+      `url(#${canvasId}__eraser-mask-0)`,
+    );
+
+    // Second stroke group (after last eraser) should NOT have a mask
+    await expect(canvas.locator(secondStrokeGroupId)).not.toHaveAttribute(
+      "mask",
+    );
+  });
+
   test("should trigger erase mode with windows surface pen eraser", async ({
     mount,
   }) => {


### PR DESCRIPTION
__PR Description:__

````
## Problem

The Canvas component renders an invalid `mask="undefined"` attribute on stroke groups when no eraser path exists for that group:

```jsx
mask={`${eraserPaths[i] && `url(#${id}__eraser-mask-${i})`}`}
````

When `eraserPaths[i]` is `undefined`, the `&&` short-circuits and returns `undefined`, which the template literal coerces to the string `"undefined"`. Per the SVG spec, valid values for the `mask` attribute are `url(#id)` or `none` — `"undefined"` is invalid.

## Fix

Use conditional property spread to omit the `mask` attribute entirely when no corresponding eraser mask exists:

```
{...(eraserPaths[i]
  ? { mask: `url(#${id}__eraser-mask-${i})` }
  : {})}
```

- With eraser mask: renders `mask="url(#rsc__eraser-mask-0)"`
- Without eraser mask: attribute is omitted entirely

## Other Changes

- Remove invalid `import { Link } from "@astrojs/check"` from `apps/docs/src/content/docs/index.mdx` (the package does not export `Link`, causing Vite dev server error)
- Fix outdated dev command in `CONTRIBUTING.md`: `pnpm start` → `pnpm dev`
- Update `.gitignore`: `.turbo/cookies/` → `.turbo/` to ignore the entire turbo cache directory

## Tests

Added 2 new test cases, all passing (4/4):

- `should not set mask attribute on stroke group when no eraser paths exist`
- `should not set mask attribute on last stroke group after erasing`


