### PR TITLE
test: add unit component and e2e coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,14 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Test
-        run: pnpm test
+      - name: Unit tests
+        run: pnpm test:unit
+
+      - name: Component tests
+        run: pnpm test:ct
+
+      - name: E2E tests
+        run: pnpm test:e2e
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"test:unit": "pnpm --filter react-sketch-canvas test:unit",
 		"test:watch": "pnpm --filter react-sketch-canvas test:watch",
 		"test:ct": "pnpm --filter react-sketch-canvas test:ct",
+		"test:e2e": "pnpm --filter react-sketch-canvas test:e2e",
 		"test": "pnpm --filter react-sketch-canvas test",
 		"ci:test": "pnpm lint && pnpm build && pnpm test",
 		"ci:build": "pnpm --filter react-sketch-canvas ci:build",

--- a/packages/react-sketch-canvas/package.json
+++ b/packages/react-sketch-canvas/package.json
@@ -44,9 +44,10 @@
 		"postpack": "node ../../scripts/package-assets.mjs postpack",
 		"test:ct": "playwright test -c playwright-ct.config.ts",
 		"test:ct:ui": "playwright test -c playwright-ct.config.ts --ui",
+		"test:e2e": "playwright test -c playwright-e2e.config.ts",
 		"test:unit": "vitest run",
 		"test:watch": "vitest",
-		"test": "pnpm test:unit && pnpm test:ct",
+		"test": "pnpm test:unit && pnpm test:ct && pnpm test:e2e",
 		"size": "size-limit"
 	},
 	"devDependencies": {

--- a/packages/react-sketch-canvas/playwright-e2e.config.ts
+++ b/packages/react-sketch-canvas/playwright-e2e.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "playwright/test";
+
+export default defineConfig({
+	testDir: "./playwright/e2e",
+	outputDir: "./test-results/e2e",
+	timeout: 10 * 1000,
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: [["html", { outputFolder: "playwright-report/e2e" }]],
+	use: {
+		baseURL: "http://127.0.0.1:3200",
+		trace: "on-first-retry",
+		...devices["Desktop Chrome"],
+	},
+	webServer: {
+		command: "pnpm exec vite playwright/e2e --host 127.0.0.1 --port 3200",
+		url: "http://127.0.0.1:3200",
+		reuseExistingServer: !process.env.CI,
+	},
+});

--- a/packages/react-sketch-canvas/playwright/e2e/canvas.spec.ts
+++ b/packages/react-sketch-canvas/playwright/e2e/canvas.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "playwright/test";
+import { drawLine } from "../../tests/commands";
+
+test("draws, exports, and clears on the browser harness", async ({ page }) => {
+	await page.goto("/");
+
+	const canvas = page.locator("#rsc");
+	await expect(canvas).toBeVisible();
+
+	await drawLine(canvas, { length: 80, originX: 20, originY: 20 });
+
+	await expect(canvas.locator("path")).toHaveCount(1);
+	await expect(page.locator("#path-count")).toHaveText("1");
+
+	await page.locator("#export-image-button").click();
+	await expect(page.locator("#exported-image")).toHaveText(
+		/^data:image\/png;base64,/,
+	);
+
+	await page.locator("#clear-button").click();
+	await expect(page.locator("#path-count")).toHaveText("0");
+	await expect(canvas.locator("path")).toHaveCount(0);
+});
+
+test("supports eraser mode with undo and redo controls", async ({ page }) => {
+	await page.goto("/");
+
+	const canvas = page.locator("#rsc");
+
+	await drawLine(canvas, { length: 80, originX: 20, originY: 20 });
+	await page.locator("#eraser-button").click();
+	await drawLine(canvas, { length: 30, originX: 20, originY: 20 });
+
+	await expect(page.locator("#path-count")).toHaveText("2");
+	await expect(canvas.locator("#rsc__eraser-stroke-group path")).toHaveCount(1);
+
+	await page.locator("#undo-button").click();
+	await expect(page.locator("#path-count")).toHaveText("1");
+	await expect(canvas.locator("#rsc__eraser-stroke-group path")).toHaveCount(0);
+
+	await page.locator("#redo-button").click();
+	await expect(page.locator("#path-count")).toHaveText("2");
+	await expect(canvas.locator("#rsc__eraser-stroke-group path")).toHaveCount(1);
+
+	await page.locator("#export-svg-button").click();
+	await expect(page.locator("#exported-svg")).toContainText("rsc__eraser-0");
+});

--- a/packages/react-sketch-canvas/playwright/e2e/index.html
+++ b/packages/react-sketch-canvas/playwright/e2e/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>React Sketch Canvas E2E</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./index.tsx"></script>
+	</body>
+</html>

--- a/packages/react-sketch-canvas/playwright/e2e/index.tsx
+++ b/packages/react-sketch-canvas/playwright/e2e/index.tsx
@@ -1,0 +1,99 @@
+import { useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+import {
+	type CanvasPath,
+	ReactSketchCanvas,
+	type ReactSketchCanvasRef,
+} from "../../src";
+
+function App() {
+	const canvasRef = useRef<ReactSketchCanvasRef>(null);
+	const [paths, setPaths] = useState<CanvasPath[]>([]);
+	const [exportedImage, setExportedImage] = useState("");
+	const [exportedSvg, setExportedSvg] = useState("");
+
+	const handleExportImage = async () => {
+		const dataUri = await canvasRef.current?.exportImage("png");
+		setExportedImage(dataUri ?? "");
+	};
+
+	const handleExportSvg = async () => {
+		const svg = await canvasRef.current?.exportSvg();
+		setExportedSvg(svg ?? "");
+	};
+
+	return (
+		<main>
+			<ReactSketchCanvas
+				ref={canvasRef}
+				id="rsc"
+				width="420px"
+				height="320px"
+				onChange={(updatedPaths) => setPaths([...updatedPaths])}
+			/>
+			<nav aria-label="Canvas controls">
+				<button
+					type="button"
+					id="pen-button"
+					onClick={() => canvasRef.current?.eraseMode(false)}
+				>
+					Pen
+				</button>
+				<button
+					type="button"
+					id="eraser-button"
+					onClick={() => canvasRef.current?.eraseMode(true)}
+				>
+					Eraser
+				</button>
+				<button
+					type="button"
+					id="undo-button"
+					onClick={() => canvasRef.current?.undo()}
+				>
+					Undo
+				</button>
+				<button
+					type="button"
+					id="redo-button"
+					onClick={() => canvasRef.current?.redo()}
+				>
+					Redo
+				</button>
+				<button
+					type="button"
+					id="clear-button"
+					onClick={() => canvasRef.current?.clearCanvas()}
+				>
+					Clear
+				</button>
+				<button
+					type="button"
+					id="reset-button"
+					onClick={() => canvasRef.current?.resetCanvas()}
+				>
+					Reset
+				</button>
+				<button
+					type="button"
+					id="export-image-button"
+					onClick={handleExportImage}
+				>
+					Export Image
+				</button>
+				<button type="button" id="export-svg-button" onClick={handleExportSvg}>
+					Export SVG
+				</button>
+			</nav>
+			<output id="path-count">{paths.length}</output>
+			<output id="exported-image">{exportedImage}</output>
+			<output id="exported-svg">{exportedSvg}</output>
+		</main>
+	);
+}
+
+const root = document.getElementById("root");
+
+if (root) {
+	createRoot(root).render(<App />);
+}

--- a/packages/react-sketch-canvas/tests/actions/exportOptions.spec.tsx
+++ b/packages/react-sketch-canvas/tests/actions/exportOptions.spec.tsx
@@ -1,0 +1,17 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { drawLine } from "../commands";
+import { WithSizedExportButton } from "../stories/WithSizedExportButton.story";
+
+test.use({ viewport: { width: 500, height: 500 } });
+
+test("exportImage uses explicit output dimensions when provided", async ({
+	mount,
+}) => {
+	const component = await mount(<WithSizedExportButton />);
+	const canvas = component.locator("#rsc");
+
+	await drawLine(canvas, { length: 50, originX: 10, originY: 10 });
+	await component.locator("#export-sized-image").click();
+
+	await expect(component.locator("#image-size")).toHaveText("123x77");
+});

--- a/packages/react-sketch-canvas/tests/events/pointerRelease.spec.tsx
+++ b/packages/react-sketch-canvas/tests/events/pointerRelease.spec.tsx
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { type CanvasPath, ReactSketchCanvas } from "../../src";
+
+test.use({ viewport: { width: 500, height: 500 } });
+
+test("document pointerup completes an in-progress stroke when the pointer leaves the canvas", async ({
+	mount,
+}) => {
+	let paths: CanvasPath[] = [];
+	const component = await mount(
+		<ReactSketchCanvas
+			id="rsc"
+			withTimestamp
+			onChange={(updatedPaths) => {
+				paths = [...updatedPaths];
+			}}
+		/>,
+	);
+
+	const canvas = component.locator("#rsc");
+	const box = await canvas.boundingBox();
+
+	if (!box) {
+		throw new Error("Canvas not found");
+	}
+
+	await canvas.dispatchEvent("pointerdown", {
+		pointerType: "pen",
+		button: 0,
+		buttons: 1,
+		clientX: box.x + 10,
+		clientY: box.y + 10,
+		pageX: box.x + 10,
+		pageY: box.y + 10,
+	});
+	await canvas.dispatchEvent("pointermove", {
+		pointerType: "pen",
+		button: 0,
+		buttons: 1,
+		clientX: box.x + 40,
+		clientY: box.y + 40,
+		pageX: box.x + 40,
+		pageY: box.y + 40,
+	});
+	await component.evaluate(() => {
+		document.dispatchEvent(
+			new PointerEvent("pointerup", {
+				pointerType: "pen",
+				button: 0,
+				buttons: 0,
+			}),
+		);
+	});
+
+	await expect.poll(() => paths.at(0)?.endTimestamp ?? 0).toBeGreaterThan(0);
+	expect(paths[0]?.paths).toHaveLength(2);
+});

--- a/packages/react-sketch-canvas/tests/stories/WithSizedExportButton.story.tsx
+++ b/packages/react-sketch-canvas/tests/stories/WithSizedExportButton.story.tsx
@@ -1,0 +1,42 @@
+import { useRef, useState } from "react";
+import {
+	ReactSketchCanvas,
+	type ReactSketchCanvasRef,
+} from "../../src/ReactSketchCanvas";
+
+export function WithSizedExportButton() {
+	const canvasRef = useRef<ReactSketchCanvasRef>(null);
+	const [imageSize, setImageSize] = useState("");
+
+	const handleExport = async () => {
+		const dataUri = await canvasRef.current?.exportImage("png", {
+			width: 123,
+			height: 77,
+		});
+
+		if (!dataUri) {
+			return;
+		}
+
+		const image = new Image();
+		image.onload = () => {
+			setImageSize(`${image.naturalWidth}x${image.naturalHeight}`);
+		};
+		image.src = dataUri;
+	};
+
+	return (
+		<div>
+			<ReactSketchCanvas
+				ref={canvasRef}
+				id="rsc"
+				width="300px"
+				height="200px"
+			/>
+			<button type="button" id="export-sized-image" onClick={handleExport}>
+				Export Sized Image
+			</button>
+			<output id="image-size">{imageSize}</output>
+		</div>
+	);
+}

--- a/packages/react-sketch-canvas/tests/unit/paths.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/paths.spec.tsx
@@ -1,0 +1,70 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SvgPath, bezierCommand, line } from "../../src/Paths";
+
+describe("Paths helpers", () => {
+	it("measures the length and angle between two points", () => {
+		const segment = line({ x: 0, y: 0 }, { x: 3, y: 4 });
+
+		expect(segment.length).toBe(5);
+		expect(segment.angle).toBeCloseTo(Math.atan2(4, 3));
+	});
+
+	it("builds a smooth cubic bezier command from neighboring points", () => {
+		const command = bezierCommand({ x: 10, y: 0 }, 1, [
+			{ x: 0, y: 0 },
+			{ x: 10, y: 0 },
+			{ x: 20, y: 10 },
+		]);
+
+		expect(command).toBe("C 2,0 5.999999999999999,-1.9999999999999998 10, 0");
+	});
+});
+
+describe("SvgPath", () => {
+	it("renders a circle for a single-point stroke", () => {
+		render(
+			<svg aria-hidden="true">
+				<SvgPath
+					id="single-point"
+					paths={[{ x: 12, y: 24 }]}
+					strokeColor="blue"
+					strokeWidth={8}
+				/>
+			</svg>,
+		);
+
+		const circle = document.querySelector("circle#single-point");
+
+		expect(circle).toBeInstanceOf(SVGCircleElement);
+		expect(circle?.getAttribute("cx")).toBe("12");
+		expect(circle?.getAttribute("cy")).toBe("24");
+		expect(circle?.getAttribute("r")).toBe("4");
+		expect(circle?.getAttribute("fill")).toBe("blue");
+	});
+
+	it("renders a path for a multi-point stroke", () => {
+		render(
+			<svg aria-hidden="true">
+				<SvgPath
+					id="multi-point"
+					paths={[
+						{ x: 0, y: 0 },
+						{ x: 10, y: 0 },
+					]}
+					strokeColor="red"
+					strokeWidth={6}
+					command={(point) => `L ${point.x},${point.y}`}
+				/>
+			</svg>,
+		);
+
+		const path = document.querySelector("path#multi-point");
+
+		expect(path).toBeInstanceOf(SVGPathElement);
+		expect(path?.getAttribute("d")).toBe("M 0,0 L 10,0");
+		expect(path?.getAttribute("stroke")).toBe("red");
+		expect(path?.getAttribute("stroke-width")).toBe("6");
+		expect(path?.getAttribute("fill")).toBe("none");
+	});
+});

--- a/packages/react-sketch-canvas/tsconfig.json
+++ b/packages/react-sketch-canvas/tsconfig.json
@@ -27,6 +27,7 @@
 		"tests",
 		"playwright",
 		"playwright-ct.config.ts",
+		"playwright-e2e.config.ts",
 		"vitest.config.ts"
 	],
 	"exclude": [


### PR DESCRIPTION
## Summary
- Add focused Vitest unit coverage for path math and SVG stroke rendering.
- Add Playwright component tests for export sizing and document-level pointer release behavior.
- Add a dedicated Playwright e2e harness and smoke tests for drawing, export, clear, eraser, undo, and redo flows.
- Run unit, component, and e2e tests explicitly in CI.

## Validation
- pnpm lint
- pnpm test
