### PR TITLE
refactor: split react sketch canvas package implementation

### DIFF
--- a/docs/superpowers/plans/2026-05-17-src-architecture-refactor.md
+++ b/docs/superpowers/plans/2026-05-17-src-architecture-refactor.md
@@ -1,0 +1,2934 @@
+# React Sketch Canvas Source Architecture Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `packages/react-sketch-canvas/src` into focused, testable modules while preserving the current public API and runtime behavior.
+
+**Architecture:** Extract pure domain logic first, then React hooks, then thin composition components. `ReactSketchCanvas` owns sketch state and public ref behavior, `Canvas` owns DOM/pointer/export behavior, `Canvas/svg` owns SVG composition, and `Paths` separates geometry from rendering.
+
+**Tech Stack:** TypeScript, React 18, Vitest, Testing Library React, happy-dom, Playwright CT/e2e, Biome, pnpm.
+
+---
+
+## Scope Check
+
+This plan implements the approved source architecture refactor in one cycle. It touches one package implementation area and its tests: `packages/react-sketch-canvas/src` and `packages/react-sketch-canvas/tests/unit`. It must not change public props, ref method names, package exports, drawing semantics, eraser semantics, export semantics, or callback timing unless a blocking bug is found and the user approves a behavior change.
+
+## File Structure
+
+Create:
+
+- `packages/react-sketch-canvas/src/Paths/geometry.ts`: pure line, control point, and bezier command helpers.
+- `packages/react-sketch-canvas/src/Paths/SvgPath.tsx`: single-stroke SVG rendering component.
+- `packages/react-sketch-canvas/src/Canvas/svg/grouping.ts`: pure eraser and draw path grouping helpers.
+- `packages/react-sketch-canvas/src/Canvas/svg/Background.tsx`: SVG background pattern and rect rendering.
+- `packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx`: hidden eraser path group and mask definitions.
+- `packages/react-sketch-canvas/src/Canvas/svg/StrokeGroups.tsx`: grouped drawing strokes with mask references.
+- `packages/react-sketch-canvas/src/Canvas/svg/CanvasSvg.tsx`: top-level SVG composition.
+- `packages/react-sketch-canvas/src/Canvas/hooks/useCanvasPointerHandlers.ts`: pointer filtering, coordinate conversion, and document `pointerup` wiring.
+- `packages/react-sketch-canvas/src/Canvas/hooks/useCanvasExportHandle.ts`: lower-level `CanvasRef` imperative export handle.
+- `packages/react-sketch-canvas/src/Canvas/export/dom.ts`: SVG clone and sizing helpers.
+- `packages/react-sketch-canvas/src/Canvas/export/svg.ts`: SVG export preparation helpers.
+- `packages/react-sketch-canvas/src/Canvas/export/image.ts`: image loading and render-canvas export helpers.
+- `packages/react-sketch-canvas/src/ReactSketchCanvas/state/strokes.ts`: pure stroke creation/update/finalization helpers.
+- `packages/react-sketch-canvas/src/ReactSketchCanvas/state/sketchingTime.ts`: pure sketching-time calculation.
+- `packages/react-sketch-canvas/src/ReactSketchCanvas/state/history.ts`: pure history and path state transitions.
+- `packages/react-sketch-canvas/src/ReactSketchCanvas/state/operations.ts`: operation type and operation reducer helpers.
+- `packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts`: React state orchestration and drawing lifecycle.
+- `packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasImperativeHandle.ts`: public `ReactSketchCanvasRef` wiring.
+- `packages/react-sketch-canvas/tests/unit/paths/geometry.spec.ts`
+- `packages/react-sketch-canvas/tests/unit/paths/SvgPath.spec.tsx`
+- `packages/react-sketch-canvas/tests/unit/canvas/grouping.spec.ts`
+- `packages/react-sketch-canvas/tests/unit/canvas/pointer.spec.ts`
+- `packages/react-sketch-canvas/tests/unit/canvas/svgExport.spec.ts`
+- `packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx`
+- `packages/react-sketch-canvas/tests/unit/canvas/useCanvasExportHandle.spec.tsx`
+- `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/strokes.spec.ts`
+- `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/sketchingTime.spec.ts`
+- `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/history.spec.ts`
+- `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/operations.spec.ts`
+- `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasController.spec.tsx`
+- `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasImperativeHandle.spec.tsx`
+
+Modify:
+
+- `packages/react-sketch-canvas/src/Paths/index.tsx`: re-export geometry and `SvgPath`, keep default `Paths`.
+- `packages/react-sketch-canvas/src/Canvas/index.tsx`: reduce to container/ref composition.
+- `packages/react-sketch-canvas/src/Canvas/types.ts`: add internal prop types only if shared by new modules.
+- `packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx`: reduce to prop defaults, controller hook, imperative hook, and `Canvas`.
+- `packages/react-sketch-canvas/tests/unit/paths.spec.tsx`: split or delete after replacement tests cover the same assertions.
+- `packages/react-sketch-canvas/tests/unit/react-sketch-canvas.spec.tsx`: keep or move into the new nested structure.
+
+---
+
+## Task 1: Baseline And Test Harness Sanity
+
+**Files:**
+
+- Read: `packages/react-sketch-canvas/src/Canvas/index.tsx`
+- Read: `packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx`
+- Read: `packages/react-sketch-canvas/src/Paths/index.tsx`
+- Read: `packages/react-sketch-canvas/vitest.config.mts`
+- Read: `packages/react-sketch-canvas/package.json`
+
+- [ ] **Step 1: Confirm the worktree is clean**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no output. If unrelated user changes exist, do not revert them; inspect whether they touch files in this plan before continuing.
+
+- [ ] **Step 2: Run current fast tests**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas test:unit
+```
+
+Expected: PASS with the existing `tests/unit/paths.spec.tsx` and `tests/unit/react-sketch-canvas.spec.tsx`.
+
+- [ ] **Step 3: Run current lint on the package**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas lint
+```
+
+Expected: PASS. If lint fails on pre-existing unrelated files, capture the exact output and ask before broad cleanup.
+
+- [ ] **Step 4: Commit only if baseline required a repo change**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no source changes from baseline commands. Do not commit generated output.
+
+---
+
+## Task 2: Extract Paths Geometry And SvgPath
+
+**Files:**
+
+- Create: `packages/react-sketch-canvas/src/Paths/geometry.ts`
+- Create: `packages/react-sketch-canvas/src/Paths/SvgPath.tsx`
+- Modify: `packages/react-sketch-canvas/src/Paths/index.tsx`
+- Create: `packages/react-sketch-canvas/tests/unit/paths/geometry.spec.ts`
+- Create: `packages/react-sketch-canvas/tests/unit/paths/SvgPath.spec.tsx`
+- Delete after replacement: `packages/react-sketch-canvas/tests/unit/paths.spec.tsx`
+
+- [ ] **Step 1: Write failing geometry tests**
+
+Create `packages/react-sketch-canvas/tests/unit/paths/geometry.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { bezierCommand, line } from "../../../src/Paths/geometry";
+
+describe("Paths geometry", () => {
+	it("measures the length and angle between two points", () => {
+		const segment = line({ x: 0, y: 0 }, { x: 3, y: 4 });
+
+		expect(segment.length).toBe(5);
+		expect(segment.angle).toBeCloseTo(Math.atan2(4, 3));
+	});
+
+	it("builds a smooth cubic bezier command from neighboring points", () => {
+		const command = bezierCommand({ x: 10, y: 0 }, 1, [
+			{ x: 0, y: 0 },
+			{ x: 10, y: 0 },
+			{ x: 20, y: 10 },
+		]);
+
+		expect(command).toBe("C 2,0 5.999999999999999,-1.9999999999999998 10, 0");
+	});
+});
+```
+
+- [ ] **Step 2: Run geometry tests and verify the expected failure**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/paths/geometry.spec.ts
+```
+
+Expected: FAIL because `src/Paths/geometry` does not exist.
+
+- [ ] **Step 3: Extract geometry helpers**
+
+Create `packages/react-sketch-canvas/src/Paths/geometry.ts`:
+
+```ts
+import type { Point } from "../types";
+
+type ControlPoints = {
+	current: Point;
+	previous?: Point;
+	next?: Point;
+	reverse?: boolean;
+};
+
+export const line = (pointA: Point, pointB: Point) => {
+	const lengthX = pointB.x - pointA.x;
+	const lengthY = pointB.y - pointA.y;
+
+	return {
+		length: Math.sqrt(lengthX ** 2 + lengthY ** 2),
+		angle: Math.atan2(lengthY, lengthX),
+	};
+};
+
+const controlPoint = (controlPoints: ControlPoints): [number, number] => {
+	const { current, next, previous, reverse } = controlPoints;
+	const p = previous || current;
+	const n = next || current;
+	const smoothing = 0.2;
+	const o = line(p, n);
+	const angle = o.angle + (reverse ? Math.PI : 0);
+	const length = o.length * smoothing;
+
+	return [
+		current.x + Math.cos(angle) * length,
+		current.y + Math.sin(angle) * length,
+	];
+};
+
+export const bezierCommand = (point: Point, i: number, a: Point[]): string => {
+	let cpsX: number;
+	let cpsY: number;
+
+	switch (i) {
+		case 0:
+			[cpsX, cpsY] = controlPoint({ current: point });
+			break;
+		case 1:
+			[cpsX, cpsY] = controlPoint({ current: a[i - 1], next: point });
+			break;
+		default:
+			[cpsX, cpsY] = controlPoint({
+				current: a[i - 1],
+				previous: a[i - 2],
+				next: point,
+			});
+			break;
+	}
+
+	const [cpeX, cpeY] = controlPoint({
+		current: point,
+		previous: a[i - 1],
+		next: a[i + 1],
+		reverse: true,
+	});
+
+	return `C ${cpsX},${cpsY} ${cpeX},${cpeY} ${point.x}, ${point.y}`;
+};
+```
+
+- [ ] **Step 4: Run geometry tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/paths/geometry.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing SvgPath tests**
+
+Create `packages/react-sketch-canvas/tests/unit/paths/SvgPath.spec.tsx`:
+
+```tsx
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SvgPath } from "../../../src/Paths/SvgPath";
+
+describe("SvgPath", () => {
+	it("renders a circle for a single-point stroke", () => {
+		render(
+			<svg aria-hidden="true">
+				<SvgPath
+					id="single-point"
+					paths={[{ x: 12, y: 24 }]}
+					strokeColor="blue"
+					strokeWidth={8}
+				/>
+			</svg>,
+		);
+
+		const circle = document.querySelector("circle#single-point");
+
+		expect(circle).toBeInstanceOf(SVGCircleElement);
+		expect(circle?.getAttribute("cx")).toBe("12");
+		expect(circle?.getAttribute("cy")).toBe("24");
+		expect(circle?.getAttribute("r")).toBe("4");
+		expect(circle?.getAttribute("fill")).toBe("blue");
+	});
+
+	it("renders a path for a multi-point stroke", () => {
+		render(
+			<svg aria-hidden="true">
+				<SvgPath
+					id="multi-point"
+					paths={[
+						{ x: 0, y: 0 },
+						{ x: 10, y: 0 },
+					]}
+					strokeColor="red"
+					strokeWidth={6}
+					command={(point) => `L ${point.x},${point.y}`}
+				/>
+			</svg>,
+		);
+
+		const path = document.querySelector("path#multi-point");
+
+		expect(path).toBeInstanceOf(SVGPathElement);
+		expect(path?.getAttribute("d")).toBe("M 0,0 L 10,0");
+		expect(path?.getAttribute("stroke")).toBe("red");
+		expect(path?.getAttribute("stroke-width")).toBe("6");
+		expect(path?.getAttribute("fill")).toBe("none");
+	});
+});
+```
+
+- [ ] **Step 6: Run SvgPath tests and verify the expected failure**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/paths/SvgPath.spec.tsx
+```
+
+Expected: FAIL because `src/Paths/SvgPath` does not exist.
+
+- [ ] **Step 7: Extract SvgPath component and update Paths barrel**
+
+Create `packages/react-sketch-canvas/src/Paths/SvgPath.tsx`:
+
+```tsx
+import type { Point } from "../types";
+import { bezierCommand } from "./geometry";
+
+export type SvgPathProps = {
+	paths: Point[];
+	id: string;
+	strokeWidth: number;
+	strokeColor: string;
+	command?: (point: Point, i: number, a: Point[]) => string;
+};
+
+export function SvgPath({
+	paths,
+	id,
+	strokeWidth,
+	strokeColor,
+	command = bezierCommand,
+}: SvgPathProps): JSX.Element {
+	if (paths.length === 1) {
+		const { x, y } = paths[0];
+		const radius = strokeWidth / 2;
+
+		return (
+			<circle
+				key={id}
+				id={id}
+				cx={x}
+				cy={y}
+				r={radius}
+				stroke={strokeColor}
+				fill={strokeColor}
+			/>
+		);
+	}
+
+	const d = paths.reduce(
+		(acc, point, i, a) =>
+			i === 0 ? `M ${point.x},${point.y}` : `${acc} ${command(point, i, a)}`,
+		"",
+	);
+
+	return (
+		<path
+			key={id}
+			id={id}
+			d={d}
+			fill="none"
+			strokeLinecap="round"
+			stroke={strokeColor}
+			strokeWidth={strokeWidth}
+		/>
+	);
+}
+```
+
+Replace `packages/react-sketch-canvas/src/Paths/index.tsx` with:
+
+```tsx
+import type { CanvasPath } from "../types";
+import { bezierCommand } from "./geometry";
+import { SvgPath } from "./SvgPath";
+
+type PathProps = {
+	id: string;
+	paths: CanvasPath[];
+};
+
+function Paths({ id, paths }: PathProps): JSX.Element {
+	return (
+		<>
+			{paths.map((path: CanvasPath, index: number) => (
+				<SvgPath
+					// biome-ignore lint/suspicious/noArrayIndexKey: stroke path order is stable and has no domain id.
+					key={`${id}__${index}`}
+					paths={path.paths}
+					id={`${id}__${index}`}
+					strokeWidth={path.strokeWidth}
+					strokeColor={path.strokeColor}
+					command={bezierCommand}
+				/>
+			))}
+		</>
+	);
+}
+
+export { bezierCommand, line } from "./geometry";
+export { SvgPath };
+export type { SvgPathProps } from "./SvgPath";
+export default Paths;
+```
+
+- [ ] **Step 8: Remove replaced old unit file**
+
+Run:
+
+```bash
+git rm packages/react-sketch-canvas/tests/unit/paths.spec.tsx
+```
+
+Expected: the old combined unit test file is removed because the new nested tests cover the same assertions.
+
+- [ ] **Step 9: Run paths unit tests**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/paths
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Run package unit tests**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas test:unit
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Commit Paths extraction**
+
+Run:
+
+```bash
+git add packages/react-sketch-canvas/src/Paths packages/react-sketch-canvas/tests/unit/paths
+git add -A packages/react-sketch-canvas/tests/unit/paths.spec.tsx
+git commit -m "refactor: split path geometry and rendering"
+```
+
+Expected: conventional commit succeeds.
+
+---
+
+## Task 3: Extract Canvas SVG Grouping And Presentational Components
+
+**Files:**
+
+- Create: `packages/react-sketch-canvas/src/Canvas/svg/grouping.ts`
+- Create: `packages/react-sketch-canvas/src/Canvas/svg/Background.tsx`
+- Create: `packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx`
+- Create: `packages/react-sketch-canvas/src/Canvas/svg/StrokeGroups.tsx`
+- Create: `packages/react-sketch-canvas/src/Canvas/svg/CanvasSvg.tsx`
+- Modify: `packages/react-sketch-canvas/src/Canvas/index.tsx`
+- Create: `packages/react-sketch-canvas/tests/unit/canvas/grouping.spec.ts`
+
+- [ ] **Step 1: Write failing grouping tests**
+
+Create `packages/react-sketch-canvas/tests/unit/canvas/grouping.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { CanvasPath } from "../../../src/types";
+import { getEraserPaths, getPathGroups } from "../../../src/Canvas/svg/grouping";
+
+const draw = (id: number): CanvasPath => ({
+	drawMode: true,
+	strokeColor: `draw-${id}`,
+	strokeWidth: id,
+	paths: [{ x: id, y: id }],
+});
+
+const erase = (id: number): CanvasPath => ({
+	drawMode: false,
+	strokeColor: "#000000",
+	strokeWidth: id,
+	paths: [{ x: id, y: id }],
+});
+
+describe("canvas SVG grouping", () => {
+	it("returns only eraser paths", () => {
+		expect(getEraserPaths([draw(1), erase(2), draw(3), erase(4)])).toEqual([
+			erase(2),
+			erase(4),
+		]);
+	});
+
+	it("groups draw paths between eraser strokes", () => {
+		expect(getPathGroups([draw(1), draw(2), erase(3), draw(4), erase(5)])).toEqual([
+			[draw(1), draw(2)],
+			[draw(4)],
+		]);
+	});
+
+	it("keeps an initial empty group when the first stroke is an eraser", () => {
+		expect(getPathGroups([erase(1), draw(2)])).toEqual([[], [draw(2)]]);
+	});
+});
+```
+
+- [ ] **Step 2: Run grouping tests and verify the expected failure**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/canvas/grouping.spec.ts
+```
+
+Expected: FAIL because `src/Canvas/svg/grouping` does not exist.
+
+- [ ] **Step 3: Extract grouping helpers**
+
+Create `packages/react-sketch-canvas/src/Canvas/svg/grouping.ts`:
+
+```ts
+import type { CanvasPath } from "../../types";
+
+export const getEraserPaths = (paths: CanvasPath[]): CanvasPath[] =>
+	paths.filter((path) => !path.drawMode);
+
+export const getPathGroups = (paths: CanvasPath[]): CanvasPath[][] => {
+	let currentGroup = 0;
+
+	return paths.reduce<CanvasPath[][]>(
+		(arrayGroup, path) => {
+			if (!path.drawMode) {
+				currentGroup += 1;
+				return arrayGroup;
+			}
+
+			if (arrayGroup[currentGroup] === undefined) {
+				arrayGroup[currentGroup] = [];
+			}
+
+			arrayGroup[currentGroup].push(path);
+			return arrayGroup;
+		},
+		[[]],
+	);
+};
+```
+
+- [ ] **Step 4: Run grouping tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/canvas/grouping.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Create Background component**
+
+Create `packages/react-sketch-canvas/src/Canvas/svg/Background.tsx`:
+
+```tsx
+import type * as React from "react";
+
+type BackgroundProps = {
+	id: string;
+	backgroundImage: string;
+	canvasColor: string;
+	preserveBackgroundImageAspectRatio?: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"];
+};
+
+export function BackgroundPattern({
+	id,
+	backgroundImage,
+	preserveBackgroundImageAspectRatio,
+}: Pick<
+	BackgroundProps,
+	"id" | "backgroundImage" | "preserveBackgroundImageAspectRatio"
+>): JSX.Element | null {
+	if (!backgroundImage) return null;
+
+	return (
+		<pattern
+			id={`${id}__background`}
+			x="0"
+			y="0"
+			width="100%"
+			height="100%"
+			patternUnits="userSpaceOnUse"
+		>
+			<image
+				x="0"
+				y="0"
+				width="100%"
+				height="100%"
+				xlinkHref={backgroundImage}
+				preserveAspectRatio={preserveBackgroundImageAspectRatio}
+			/>
+		</pattern>
+	);
+}
+
+export function BackgroundRect({
+	id,
+	backgroundImage,
+	canvasColor,
+}: Pick<BackgroundProps, "id" | "backgroundImage" | "canvasColor">): JSX.Element {
+	return (
+		<g id={`${id}__canvas-background-group`}>
+			<rect
+				id={`${id}__canvas-background`}
+				x="0"
+				y="0"
+				width="100%"
+				height="100%"
+				fill={backgroundImage ? `url(#${id}__background)` : canvasColor}
+			/>
+		</g>
+	);
+}
+```
+
+- [ ] **Step 6: Create EraserMasks component**
+
+Create `packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx`:
+
+```tsx
+import { SvgPath } from "../../Paths";
+import type { CanvasPath } from "../../types";
+
+type EraserMasksProps = {
+	id: string;
+	eraserPaths: CanvasPath[];
+};
+
+export function HiddenEraserStrokes({
+	id,
+	eraserPaths,
+}: EraserMasksProps): JSX.Element {
+	return (
+		<g id={`${id}__eraser-stroke-group`} display="none">
+			<rect
+				id={`${id}__mask-background`}
+				x="0"
+				y="0"
+				width="100%"
+				height="100%"
+				fill="white"
+			/>
+			{eraserPaths.map((eraserPath, i) => (
+				<SvgPath
+					// biome-ignore lint/suspicious/noArrayIndexKey: eraser masks are generated from ordered strokes with no domain id.
+					key={`${id}__eraser-${i}`}
+					id={`${id}__eraser-${i}`}
+					paths={eraserPath.paths}
+					strokeColor="#000000"
+					strokeWidth={eraserPath.strokeWidth}
+				/>
+			))}
+		</g>
+	);
+}
+
+export function EraserMaskDefs({
+	id,
+	eraserPaths,
+}: EraserMasksProps): JSX.Element {
+	return (
+		<>
+			{eraserPaths.map((_, i) => (
+				<mask
+					id={`${id}__eraser-mask-${i}`}
+					// biome-ignore lint/suspicious/noArrayIndexKey: mask order is tied to ordered eraser strokes.
+					key={`${id}__eraser-mask-${i}`}
+					maskUnits="userSpaceOnUse"
+				>
+					<use
+						href={`#${id}__mask-background`}
+						xlinkHref={`#${id}__mask-background`}
+					/>
+					{Array.from({ length: eraserPaths.length - i }, (_i, j) => j + i).map(
+						(k) => (
+							<use
+								key={k.toString()}
+								href={`#${id}__eraser-${k.toString()}`}
+								xlinkHref={`#${id}__eraser-${k.toString()}`}
+							/>
+						),
+					)}
+				</mask>
+			))}
+		</>
+	);
+}
+```
+
+- [ ] **Step 7: Create StrokeGroups component**
+
+Create `packages/react-sketch-canvas/src/Canvas/svg/StrokeGroups.tsx`:
+
+```tsx
+import Paths from "../../Paths";
+import type { CanvasPath } from "../../types";
+
+type StrokeGroupsProps = {
+	id: string;
+	pathGroups: CanvasPath[][];
+	eraserPaths: CanvasPath[];
+};
+
+export function StrokeGroups({
+	id,
+	pathGroups,
+	eraserPaths,
+}: StrokeGroupsProps): JSX.Element {
+	return (
+		<>
+			{pathGroups.map((pathGroup, i) => (
+				<g
+					id={`${id}__stroke-group-${i}`}
+					// biome-ignore lint/suspicious/noArrayIndexKey: stroke groups are ordered drawing segments with no domain id.
+					key={`${id}__stroke-group-${i}`}
+					{...(eraserPaths[i] ? { mask: `url(#${id}__eraser-mask-${i})` } : {})}
+				>
+					<Paths id={`${id}__stroke-group-${i}__paths`} paths={pathGroup} />
+				</g>
+			))}
+		</>
+	);
+}
+```
+
+- [ ] **Step 8: Create CanvasSvg component**
+
+Create `packages/react-sketch-canvas/src/Canvas/svg/CanvasSvg.tsx`:
+
+```tsx
+import type * as React from "react";
+import type { CanvasPath } from "../../types";
+import { BackgroundPattern, BackgroundRect } from "./Background";
+import { EraserMaskDefs, HiddenEraserStrokes } from "./EraserMasks";
+import { getEraserPaths, getPathGroups } from "./grouping";
+import { StrokeGroups } from "./StrokeGroups";
+
+type CanvasSvgProps = {
+	id: string;
+	paths: CanvasPath[];
+	canvasColor: string;
+	backgroundImage: string;
+	preserveBackgroundImageAspectRatio?: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"];
+	svgStyle: React.CSSProperties;
+	viewBox?: string;
+};
+
+export function CanvasSvg({
+	id,
+	paths,
+	canvasColor,
+	backgroundImage,
+	preserveBackgroundImageAspectRatio,
+	svgStyle,
+	viewBox,
+}: CanvasSvgProps): JSX.Element {
+	const eraserPaths = getEraserPaths(paths);
+	const pathGroups = getPathGroups(paths);
+
+	return (
+		<svg
+			version="1.1"
+			baseProfile="full"
+			xmlns="http://www.w3.org/2000/svg"
+			xmlnsXlink="http://www.w3.org/1999/xlink"
+			aria-hidden="true"
+			style={{
+				width: "100%",
+				height: "100%",
+				...svgStyle,
+			}}
+			id={id}
+			viewBox={viewBox}
+		>
+			<HiddenEraserStrokes id={id} eraserPaths={eraserPaths} />
+			<defs>
+				<BackgroundPattern
+					id={id}
+					backgroundImage={backgroundImage}
+					preserveBackgroundImageAspectRatio={preserveBackgroundImageAspectRatio}
+				/>
+				<EraserMaskDefs id={id} eraserPaths={eraserPaths} />
+			</defs>
+			<BackgroundRect
+				id={id}
+				backgroundImage={backgroundImage}
+				canvasColor={canvasColor}
+			/>
+			<StrokeGroups id={id} pathGroups={pathGroups} eraserPaths={eraserPaths} />
+		</svg>
+	);
+}
+```
+
+- [ ] **Step 9: Replace inline SVG rendering in Canvas**
+
+In `packages/react-sketch-canvas/src/Canvas/index.tsx`, add:
+
+```ts
+import { CanvasSvg } from "./svg/CanvasSvg";
+```
+
+Remove the local `eraserPaths` and `pathGroups` `useMemo` blocks. Replace the inline `<svg>...</svg>` block in the return with:
+
+```tsx
+<CanvasSvg
+	id={id}
+	paths={paths}
+	canvasColor={canvasColor}
+	backgroundImage={backgroundImage}
+	preserveBackgroundImageAspectRatio={preserveBackgroundImageAspectRatio}
+	svgStyle={svgStyle}
+	viewBox={viewBox}
+/>
+```
+
+Also remove imports that become unused after deleting inline SVG logic:
+
+```ts
+import Paths, { SvgPath } from "../Paths";
+import type { CanvasPath } from "../types";
+```
+
+Keep the remaining type imports needed by export and pointer logic.
+
+- [ ] **Step 10: Run canvas grouping and unit tests**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/canvas/grouping.spec.ts
+pnpm --filter react-sketch-canvas test:unit
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 11: Run Playwright canvas smoke tests**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas test:ct -- tests/canvas/canvas.spec.tsx tests/actions/erase.spec.tsx
+```
+
+Expected: PASS. These tests guard that SVG composition and eraser behavior still render correctly in a browser.
+
+- [ ] **Step 12: Commit Canvas SVG extraction**
+
+Run:
+
+```bash
+git add packages/react-sketch-canvas/src/Canvas packages/react-sketch-canvas/tests/unit/canvas/grouping.spec.ts
+git commit -m "refactor: split canvas svg rendering"
+```
+
+Expected: conventional commit succeeds.
+
+---
+
+## Task 4: Extract Canvas Pointer Handling
+
+**Files:**
+
+- Create: `packages/react-sketch-canvas/src/Canvas/hooks/useCanvasPointerHandlers.ts`
+- Modify: `packages/react-sketch-canvas/src/Canvas/index.tsx`
+- Create: `packages/react-sketch-canvas/tests/unit/canvas/pointer.spec.ts`
+- Create: `packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx`
+
+- [ ] **Step 1: Write failing pure pointer tests**
+
+Create `packages/react-sketch-canvas/tests/unit/canvas/pointer.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+	getCanvasPoint,
+	isAllowedPointerType,
+	isPenEraser,
+	shouldHandlePointerButton,
+} from "../../../src/Canvas/hooks/useCanvasPointerHandlers";
+
+describe("canvas pointer helpers", () => {
+	it("allows all pointer types when configured as all", () => {
+		expect(isAllowedPointerType("all", "mouse")).toBe(true);
+		expect(isAllowedPointerType("all", "pen")).toBe(true);
+		expect(isAllowedPointerType("all", "touch")).toBe(true);
+	});
+
+	it("rejects pointer types that do not match the configured type", () => {
+		expect(isAllowedPointerType("pen", "mouse")).toBe(false);
+		expect(isAllowedPointerType("pen", "pen")).toBe(true);
+	});
+
+	it("ignores non-primary mouse buttons", () => {
+		expect(shouldHandlePointerButton("mouse", 0)).toBe(true);
+		expect(shouldHandlePointerButton("mouse", 2)).toBe(false);
+		expect(shouldHandlePointerButton("pen", 5)).toBe(true);
+	});
+
+	it("detects pen eraser button bit", () => {
+		expect(isPenEraser("pen", 32)).toBe(true);
+		expect(isPenEraser("pen", 64)).toBe(false);
+		expect(isPenEraser("mouse", 32)).toBe(false);
+	});
+
+	it("converts page coordinates into canvas-relative coordinates", () => {
+		const point = getCanvasPoint(
+			{ pageX: 150, pageY: 220 },
+			{ left: 100, top: 200 },
+			{ scrollX: 10, scrollY: 20 },
+		);
+
+		expect(point).toEqual({ x: 40, y: 0 });
+	});
+});
+```
+
+- [ ] **Step 2: Run pointer tests and verify the expected failure**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/canvas/pointer.spec.ts
+```
+
+Expected: FAIL because `useCanvasPointerHandlers` does not exist.
+
+- [ ] **Step 3: Create pointer hook and pure helpers**
+
+Create `packages/react-sketch-canvas/src/Canvas/hooks/useCanvasPointerHandlers.ts`:
+
+```ts
+import * as React from "react";
+import { useCallback } from "react";
+import type { AllowOnlyPointerType } from "../types";
+import type { Point } from "../../types";
+
+const ERASER_BUTTON_MASK = 32;
+
+type PointerLike = {
+	pageX: number;
+	pageY: number;
+};
+
+type BoundsLike = {
+	left: number;
+	top: number;
+};
+
+type ScrollLike = {
+	scrollX: number;
+	scrollY: number;
+};
+
+type UseCanvasPointerHandlersParams = {
+	canvasRef: React.RefObject<HTMLDivElement>;
+	canvasSizeRef: React.MutableRefObject<{ width: number; height: number } | null>;
+	isDrawing: boolean;
+	allowOnlyPointerType: AllowOnlyPointerType;
+	onPointerDown: (point: Point, isEraser?: boolean) => void;
+	onPointerMove: (point: Point) => void;
+	onPointerUp: () => void;
+};
+
+export const isAllowedPointerType = (
+	allowOnlyPointerType: AllowOnlyPointerType,
+	pointerType: string,
+): boolean =>
+	allowOnlyPointerType === "all" || pointerType === allowOnlyPointerType;
+
+export const shouldHandlePointerButton = (
+	pointerType: string,
+	button: number,
+): boolean => !(pointerType === "mouse" && button !== 0);
+
+export const isPenEraser = (pointerType: string, buttons: number): boolean =>
+	pointerType === "pen" && Math.floor(buttons / ERASER_BUTTON_MASK) % 2 === 1;
+
+export const getCanvasPoint = (
+	pointerEvent: PointerLike,
+	boundingArea: BoundsLike,
+	scroll: ScrollLike,
+): Point => ({
+	x: pointerEvent.pageX - boundingArea.left - scroll.scrollX,
+	y: pointerEvent.pageY - boundingArea.top - scroll.scrollY,
+});
+
+export function useCanvasPointerHandlers({
+	canvasRef,
+	canvasSizeRef,
+	isDrawing,
+	allowOnlyPointerType,
+	onPointerDown,
+	onPointerMove,
+	onPointerUp,
+}: UseCanvasPointerHandlersParams) {
+	const getCoordinates = useCallback(
+		(pointerEvent: React.PointerEvent<HTMLDivElement>): Point => {
+			const boundingArea = canvasRef.current?.getBoundingClientRect();
+			canvasSizeRef.current = boundingArea
+				? { width: boundingArea.width, height: boundingArea.height }
+				: null;
+
+			if (!boundingArea) {
+				return { x: 0, y: 0 };
+			}
+
+			return getCanvasPoint(pointerEvent, boundingArea, {
+				scrollX: window.scrollX ?? 0,
+				scrollY: window.scrollY ?? 0,
+			});
+		},
+		[canvasRef, canvasSizeRef],
+	);
+
+	const handlePointerDown = useCallback(
+		(event: React.PointerEvent<HTMLDivElement>): void => {
+			if (!isAllowedPointerType(allowOnlyPointerType, event.pointerType)) return;
+			if (!shouldHandlePointerButton(event.pointerType, event.button)) return;
+
+			onPointerDown(
+				getCoordinates(event),
+				isPenEraser(event.pointerType, event.buttons),
+			);
+		},
+		[allowOnlyPointerType, getCoordinates, onPointerDown],
+	);
+
+	const handlePointerMove = useCallback(
+		(event: React.PointerEvent<HTMLDivElement>): void => {
+			if (!isDrawing) return;
+			if (!isAllowedPointerType(allowOnlyPointerType, event.pointerType)) return;
+
+			onPointerMove(getCoordinates(event));
+		},
+		[allowOnlyPointerType, getCoordinates, isDrawing, onPointerMove],
+	);
+
+	const handlePointerUp = useCallback(
+		(event: React.PointerEvent<HTMLDivElement> | PointerEvent): void => {
+			if (!shouldHandlePointerButton(event.pointerType, event.button)) return;
+			if (!isAllowedPointerType(allowOnlyPointerType, event.pointerType)) return;
+
+			onPointerUp();
+		},
+		[allowOnlyPointerType, onPointerUp],
+	);
+
+	React.useEffect(() => {
+		document.addEventListener("pointerup", handlePointerUp);
+		return () => {
+			document.removeEventListener("pointerup", handlePointerUp);
+		};
+	}, [handlePointerUp]);
+
+	return {
+		handlePointerDown,
+		handlePointerMove,
+		handlePointerUp,
+	};
+}
+```
+
+- [ ] **Step 4: Run pure pointer tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/canvas/pointer.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write hook harness tests**
+
+Create `packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx`:
+
+```tsx
+import { fireEvent, render } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useCanvasPointerHandlers } from "../../../src/Canvas/hooks/useCanvasPointerHandlers";
+import type { AllowOnlyPointerType } from "../../../src/Canvas/types";
+import type { Point } from "../../../src/types";
+
+type HarnessProps = {
+	isDrawing?: boolean;
+	allowOnlyPointerType?: AllowOnlyPointerType;
+	onPointerDown?: (point: Point, isEraser?: boolean) => void;
+	onPointerMove?: (point: Point) => void;
+	onPointerUp?: () => void;
+};
+
+function Harness({
+	isDrawing = false,
+	allowOnlyPointerType = "all",
+	onPointerDown = vi.fn(),
+	onPointerMove = vi.fn(),
+	onPointerUp = vi.fn(),
+}: HarnessProps) {
+	const canvasRef = React.useRef<HTMLDivElement>(null);
+	const canvasSizeRef = React.useRef<{ width: number; height: number } | null>(null);
+	const handlers = useCanvasPointerHandlers({
+		canvasRef,
+		canvasSizeRef,
+		isDrawing,
+		allowOnlyPointerType,
+		onPointerDown,
+		onPointerMove,
+		onPointerUp,
+	});
+
+	React.useEffect(() => {
+		if (!canvasRef.current) return;
+		canvasRef.current.getBoundingClientRect = () =>
+			({
+				left: 10,
+				top: 20,
+				width: 300,
+				height: 200,
+			}) as DOMRect;
+	}, []);
+
+	return <div data-testid="canvas" ref={canvasRef} {...handlers} />;
+}
+
+describe("useCanvasPointerHandlers", () => {
+	it("normalizes pointer down into a canvas point", () => {
+		const onPointerDown = vi.fn();
+		const { getByTestId } = render(<Harness onPointerDown={onPointerDown} />);
+
+		fireEvent.pointerDown(getByTestId("canvas"), {
+			pointerType: "mouse",
+			button: 0,
+			buttons: 1,
+			pageX: 40,
+			pageY: 70,
+		});
+
+		expect(onPointerDown).toHaveBeenCalledWith({ x: 30, y: 50 }, false);
+	});
+
+	it("does not move when drawing is false", () => {
+		const onPointerMove = vi.fn();
+		const { getByTestId } = render(<Harness onPointerMove={onPointerMove} />);
+
+		fireEvent.pointerMove(getByTestId("canvas"), {
+			pointerType: "mouse",
+			pageX: 40,
+			pageY: 70,
+		});
+
+		expect(onPointerMove).not.toHaveBeenCalled();
+	});
+
+	it("wires document pointerup", () => {
+		const onPointerUp = vi.fn();
+		render(<Harness onPointerUp={onPointerUp} />);
+
+		fireEvent.pointerUp(document, { pointerType: "mouse", button: 0 });
+
+		expect(onPointerUp).toHaveBeenCalledOnce();
+	});
+});
+```
+
+- [ ] **Step 6: Run hook tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/canvas/useCanvasPointerHandlers.spec.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Replace inline pointer logic in Canvas**
+
+In `packages/react-sketch-canvas/src/Canvas/index.tsx`, remove:
+
+- `ERASER_BUTTON_MASK`
+- local `getCoordinates`
+- local `handlePointerDown`
+- local `handlePointerMove`
+- local `handlePointerUp`
+- the document `pointerup` `useEffect`
+
+Add:
+
+```ts
+import { useCanvasPointerHandlers } from "./hooks/useCanvasPointerHandlers";
+```
+
+Inside `Canvas`, after refs are declared, add:
+
+```ts
+const { handlePointerDown, handlePointerMove, handlePointerUp } =
+	useCanvasPointerHandlers({
+		canvasRef,
+		canvasSizeRef,
+		isDrawing,
+		allowOnlyPointerType,
+		onPointerDown,
+		onPointerMove,
+		onPointerUp,
+	});
+```
+
+- [ ] **Step 8: Run unit and pointer release tests**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas test:unit
+pnpm --filter react-sketch-canvas test:ct -- tests/events/pointerRelease.spec.tsx tests/events/events.spec.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit pointer extraction**
+
+Run:
+
+```bash
+git add packages/react-sketch-canvas/src/Canvas packages/react-sketch-canvas/tests/unit/canvas/pointer.spec.ts packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx
+git commit -m "refactor: extract canvas pointer handling"
+```
+
+Expected: conventional commit succeeds.
+
+---
+
+## Task 5: Extract Canvas Export Helpers And Export Hook
+
+**Files:**
+
+- Create: `packages/react-sketch-canvas/src/Canvas/export/dom.ts`
+- Create: `packages/react-sketch-canvas/src/Canvas/export/svg.ts`
+- Create: `packages/react-sketch-canvas/src/Canvas/export/image.ts`
+- Create: `packages/react-sketch-canvas/src/Canvas/hooks/useCanvasExportHandle.ts`
+- Modify: `packages/react-sketch-canvas/src/Canvas/index.tsx`
+- Create: `packages/react-sketch-canvas/tests/unit/canvas/svgExport.spec.ts`
+- Create: `packages/react-sketch-canvas/tests/unit/canvas/useCanvasExportHandle.spec.tsx`
+
+- [ ] **Step 1: Write failing SVG export helper tests**
+
+Create `packages/react-sketch-canvas/tests/unit/canvas/svgExport.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { getCanvasWithViewBox } from "../../../src/Canvas/export/dom";
+import { prepareSvgForExport } from "../../../src/Canvas/export/svg";
+
+describe("canvas SVG export helpers", () => {
+	it("clones the svg and applies explicit width, height, and viewBox", () => {
+		const wrapper = document.createElement("div");
+		Object.defineProperties(wrapper, {
+			offsetWidth: { value: 320 },
+			offsetHeight: { value: 180 },
+		});
+		wrapper.innerHTML = `<svg id="sketch"></svg>`;
+
+		const result = getCanvasWithViewBox(wrapper);
+
+		expect(result.width).toBe(320);
+		expect(result.height).toBe(180);
+		expect(result.svgCanvas.getAttribute("viewBox")).toBe("0 0 320 180");
+		expect(result.svgCanvas.getAttribute("width")).toBe("320");
+		expect(result.svgCanvas.getAttribute("height")).toBe("180");
+	});
+
+	it("keeps the background image pattern when exporting with background image", () => {
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.innerHTML = `
+			<defs><pattern id="canvas__background"></pattern></defs>
+			<rect id="canvas__canvas-background" fill="url(#canvas__background)"></rect>
+		`;
+
+		prepareSvgForExport(svg, {
+			id: "canvas",
+			canvasColor: "white",
+			exportWithBackgroundImage: true,
+		});
+
+		expect(svg.querySelector("#canvas__background")).not.toBeNull();
+	});
+
+	it("removes the background image pattern and restores canvas color when exporting without background image", () => {
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.innerHTML = `
+			<defs><pattern id="canvas__background"></pattern></defs>
+			<rect id="canvas__canvas-background" fill="url(#canvas__background)"></rect>
+		`;
+
+		prepareSvgForExport(svg, {
+			id: "canvas",
+			canvasColor: "pink",
+			exportWithBackgroundImage: false,
+		});
+
+		expect(svg.querySelector("#canvas__background")).toBeNull();
+		expect(svg.querySelector("#canvas__canvas-background")?.getAttribute("fill")).toBe(
+			"pink",
+		);
+	});
+});
+```
+
+- [ ] **Step 2: Run SVG export tests and verify the expected failure**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/canvas/svgExport.spec.ts
+```
+
+Expected: FAIL because export helper modules do not exist.
+
+- [ ] **Step 3: Extract DOM and SVG export helpers**
+
+Create `packages/react-sketch-canvas/src/Canvas/export/dom.ts`:
+
+```ts
+export function getCanvasWithViewBox(canvas: HTMLDivElement) {
+	const svgCanvas = canvas.firstChild?.cloneNode(true) as SVGElement;
+	const width = canvas.offsetWidth;
+	const height = canvas.offsetHeight;
+
+	svgCanvas.setAttribute("viewBox", `0 0 ${width} ${height}`);
+	svgCanvas.setAttribute("width", width.toString());
+	svgCanvas.setAttribute("height", height.toString());
+
+	return { svgCanvas, width, height };
+}
+```
+
+Create `packages/react-sketch-canvas/src/Canvas/export/svg.ts`:
+
+```ts
+type PrepareSvgForExportOptions = {
+	id: string;
+	canvasColor: string;
+	exportWithBackgroundImage: boolean;
+};
+
+export function prepareSvgForExport(
+	svgCanvas: SVGElement,
+	{ id, canvasColor, exportWithBackgroundImage }: PrepareSvgForExportOptions,
+): SVGElement {
+	if (exportWithBackgroundImage) {
+		return svgCanvas;
+	}
+
+	svgCanvas.querySelector(`#${id}__background`)?.remove();
+	svgCanvas
+		.querySelector(`#${id}__canvas-background`)
+		?.setAttribute("fill", canvasColor);
+
+	return svgCanvas;
+}
+```
+
+- [ ] **Step 4: Run SVG export helper tests and verify they pass**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/canvas/svgExport.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Extract image export helper**
+
+Create `packages/react-sketch-canvas/src/Canvas/export/image.ts`:
+
+```ts
+import type { ExportImageOptions, ExportImageType } from "../../types";
+
+export const loadImage = (url: string): Promise<HTMLImageElement> =>
+	new Promise((resolve, reject) => {
+		const img = new Image();
+		img.addEventListener("load", () => {
+			if (img.width > 0) {
+				resolve(img);
+				return;
+			}
+			reject(new Error("Image not found"));
+		});
+		img.addEventListener("error", (err) => reject(err));
+		img.src = url;
+		img.setAttribute("crossorigin", "anonymous");
+	});
+
+type ExportImageFromSvgOptions = {
+	svgCanvas: SVGElement;
+	svgWidth: number;
+	svgHeight: number;
+	imageType: ExportImageType;
+	canvasColor: string;
+	backgroundImage: string;
+	exportWithBackgroundImage: boolean;
+	options?: ExportImageOptions;
+};
+
+export async function exportImageFromSvg({
+	svgCanvas,
+	svgWidth,
+	svgHeight,
+	imageType,
+	canvasColor,
+	backgroundImage,
+	exportWithBackgroundImage,
+	options,
+}: ExportImageFromSvgOptions): Promise<string> {
+	const exportWidth = options?.width ?? svgWidth;
+	const exportHeight = options?.height ?? svgHeight;
+	const canvasSketch = `data:image/svg+xml;base64,${btoa(svgCanvas.outerHTML)}`;
+	const loadImagePromises = [loadImage(canvasSketch)];
+
+	if (exportWithBackgroundImage && backgroundImage) {
+		try {
+			loadImagePromises.push(loadImage(backgroundImage));
+		} catch {
+			console.warn(
+				"exportWithBackgroundImage props is set without a valid background image URL. This option is ignored",
+			);
+		}
+	}
+
+	const images = await Promise.all(loadImagePromises);
+	const renderCanvas = document.createElement("canvas");
+	renderCanvas.setAttribute("width", exportWidth.toString());
+	renderCanvas.setAttribute("height", exportHeight.toString());
+	const context = renderCanvas.getContext("2d");
+
+	if (!context) {
+		throw Error("Canvas not rendered yet");
+	}
+
+	if (imageType === "jpeg" && !exportWithBackgroundImage) {
+		context.fillStyle = canvasColor;
+		context.fillRect(0, 0, exportWidth, exportHeight);
+	}
+
+	for (const image of images.reverse()) {
+		context.drawImage(image, 0, 0, exportWidth, exportHeight);
+	}
+
+	return renderCanvas.toDataURL(`image/${imageType}`);
+}
+```
+
+- [ ] **Step 6: Write export hook tests**
+
+Create `packages/react-sketch-canvas/tests/unit/canvas/useCanvasExportHandle.spec.tsx`:
+
+```tsx
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+import type { CanvasRef } from "../../../src/Canvas/types";
+import { useCanvasExportHandle } from "../../../src/Canvas/hooks/useCanvasExportHandle";
+
+function Harness({ canvasRef }: { canvasRef: React.RefObject<CanvasRef> }) {
+	const wrapperRef = React.useRef<HTMLDivElement>(null);
+
+	useCanvasExportHandle(canvasRef, {
+		canvasRef: wrapperRef,
+		id: "hook-canvas",
+		canvasColor: "white",
+		backgroundImage: "",
+		exportWithBackgroundImage: false,
+	});
+
+	return (
+		<div ref={wrapperRef}>
+			<svg id="hook-canvas">
+				<rect id="hook-canvas__canvas-background" fill="white" />
+			</svg>
+		</div>
+	);
+}
+
+describe("useCanvasExportHandle", () => {
+	it("exposes exportSvg through the forwarded ref", async () => {
+		const canvasRef = React.createRef<CanvasRef>();
+
+		render(<Harness canvasRef={canvasRef} />);
+
+		await expect(canvasRef.current?.exportSvg()).resolves.toContain(
+			'id="hook-canvas"',
+		);
+	});
+});
+```
+
+- [ ] **Step 7: Create export hook**
+
+Create `packages/react-sketch-canvas/src/Canvas/hooks/useCanvasExportHandle.ts`:
+
+```ts
+import * as React from "react";
+import type { CanvasRef } from "../types";
+import type { ExportImageOptions, ExportImageType } from "../../types";
+import { getCanvasWithViewBox } from "../export/dom";
+import { exportImageFromSvg } from "../export/image";
+import { prepareSvgForExport } from "../export/svg";
+
+type UseCanvasExportHandleOptions = {
+	canvasRef: React.RefObject<HTMLDivElement>;
+	id: string;
+	canvasColor: string;
+	backgroundImage: string;
+	exportWithBackgroundImage: boolean;
+};
+
+export function useCanvasExportHandle(
+	ref: React.ForwardedRef<CanvasRef>,
+	{
+		canvasRef,
+		id,
+		canvasColor,
+		backgroundImage,
+		exportWithBackgroundImage,
+	}: UseCanvasExportHandleOptions,
+): void {
+	React.useImperativeHandle(ref, () => ({
+		exportImage: async (
+			imageType: ExportImageType,
+			options?: ExportImageOptions,
+		): Promise<string> => {
+			const canvas = canvasRef.current;
+
+			if (!canvas) {
+				throw Error("Canvas not rendered yet");
+			}
+
+			const { svgCanvas, width, height } = getCanvasWithViewBox(canvas);
+
+			return exportImageFromSvg({
+				svgCanvas,
+				svgWidth: width,
+				svgHeight: height,
+				imageType,
+				canvasColor,
+				backgroundImage,
+				exportWithBackgroundImage,
+				options,
+			});
+		},
+		exportSvg: async (): Promise<string> => {
+			const canvas = canvasRef.current;
+
+			if (!canvas) {
+				throw new Error("Canvas not loaded");
+			}
+
+			const { svgCanvas } = getCanvasWithViewBox(canvas);
+			return prepareSvgForExport(svgCanvas, {
+				id,
+				canvasColor,
+				exportWithBackgroundImage,
+			}).outerHTML;
+		},
+	}));
+}
+```
+
+- [ ] **Step 8: Run export hook tests**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/canvas/useCanvasExportHandle.spec.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Replace inline export logic in Canvas**
+
+In `packages/react-sketch-canvas/src/Canvas/index.tsx`, remove:
+
+- local `loadImage`
+- local `getCanvasWithViewBox`
+- inline `React.useImperativeHandle` export block
+
+Add:
+
+```ts
+import { useCanvasExportHandle } from "./hooks/useCanvasExportHandle";
+```
+
+Inside `Canvas`, after refs are declared, add:
+
+```ts
+useCanvasExportHandle(ref, {
+	canvasRef,
+	id,
+	canvasColor,
+	backgroundImage,
+	exportWithBackgroundImage,
+});
+```
+
+- [ ] **Step 10: Run export-focused tests**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas test:unit
+pnpm --filter react-sketch-canvas test:ct -- tests/actions/export.spec.tsx tests/actions/exportOptions.spec.tsx
+```
+
+Expected: PASS. These Playwright tests guard browser image export behavior that happy-dom cannot fully validate.
+
+- [ ] **Step 11: Commit export extraction**
+
+Run:
+
+```bash
+git add packages/react-sketch-canvas/src/Canvas packages/react-sketch-canvas/tests/unit/canvas/svgExport.spec.ts packages/react-sketch-canvas/tests/unit/canvas/useCanvasExportHandle.spec.tsx
+git commit -m "refactor: extract canvas export handling"
+```
+
+Expected: conventional commit succeeds.
+
+---
+
+## Task 6: Extract ReactSketchCanvas Pure State Modules
+
+**Files:**
+
+- Create: `packages/react-sketch-canvas/src/ReactSketchCanvas/state/strokes.ts`
+- Create: `packages/react-sketch-canvas/src/ReactSketchCanvas/state/sketchingTime.ts`
+- Create: `packages/react-sketch-canvas/src/ReactSketchCanvas/state/history.ts`
+- Create: `packages/react-sketch-canvas/src/ReactSketchCanvas/state/operations.ts`
+- Create: `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/strokes.spec.ts`
+- Create: `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/sketchingTime.spec.ts`
+- Create: `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/history.spec.ts`
+- Create: `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/operations.spec.ts`
+
+- [ ] **Step 1: Write failing stroke tests**
+
+Create `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/strokes.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+	appendPointToLastStroke,
+	createStroke,
+	finishStroke,
+} from "../../../src/ReactSketchCanvas/state/strokes";
+
+describe("stroke state helpers", () => {
+	it("creates a draw stroke", () => {
+		expect(
+			createStroke({
+				point: { x: 1, y: 2 },
+				drawMode: true,
+				strokeColor: "red",
+				strokeWidth: 4,
+				eraserWidth: 8,
+				withTimestamp: false,
+				now: 100,
+			}),
+		).toEqual({
+			drawMode: true,
+			strokeColor: "red",
+			strokeWidth: 4,
+			paths: [{ x: 1, y: 2 }],
+		});
+	});
+
+	it("creates an eraser stroke when draw mode is false", () => {
+		expect(
+			createStroke({
+				point: { x: 1, y: 2 },
+				drawMode: false,
+				strokeColor: "red",
+				strokeWidth: 4,
+				eraserWidth: 8,
+				withTimestamp: true,
+				now: 100,
+			}),
+		).toEqual({
+			drawMode: false,
+			strokeColor: "#000000",
+			strokeWidth: 8,
+			paths: [{ x: 1, y: 2 }],
+			startTimestamp: 100,
+			endTimestamp: 0,
+		});
+	});
+
+	it("appends a point to the last stroke", () => {
+		const paths = [
+			createStroke({
+				point: { x: 1, y: 2 },
+				drawMode: true,
+				strokeColor: "red",
+				strokeWidth: 4,
+				eraserWidth: 8,
+				withTimestamp: false,
+				now: 100,
+			}),
+		];
+
+		expect(appendPointToLastStroke(paths, { x: 3, y: 4 })[0].paths).toEqual([
+			{ x: 1, y: 2 },
+			{ x: 3, y: 4 },
+		]);
+	});
+
+	it("finishes timestamped last stroke", () => {
+		const paths = [
+			createStroke({
+				point: { x: 1, y: 2 },
+				drawMode: true,
+				strokeColor: "red",
+				strokeWidth: 4,
+				eraserWidth: 8,
+				withTimestamp: true,
+				now: 100,
+			}),
+		];
+
+		expect(finishStroke(paths, true, 250)[0].endTimestamp).toBe(250);
+		expect(finishStroke(paths, false, 250)[0].endTimestamp).toBe(0);
+	});
+});
+```
+
+- [ ] **Step 2: Create stroke helpers**
+
+Create `packages/react-sketch-canvas/src/ReactSketchCanvas/state/strokes.ts`:
+
+```ts
+import type { CanvasPath, Point } from "../../types";
+
+type CreateStrokeOptions = {
+	point: Point;
+	drawMode: boolean;
+	strokeColor: string;
+	strokeWidth: number;
+	eraserWidth: number;
+	withTimestamp: boolean;
+	now: number;
+};
+
+export function createStroke({
+	point,
+	drawMode,
+	strokeColor,
+	strokeWidth,
+	eraserWidth,
+	withTimestamp,
+	now,
+}: CreateStrokeOptions): CanvasPath {
+	const stroke: CanvasPath = {
+		drawMode,
+		strokeColor: drawMode ? strokeColor : "#000000",
+		strokeWidth: drawMode ? strokeWidth : eraserWidth,
+		paths: [point],
+	};
+
+	if (!withTimestamp) {
+		return stroke;
+	}
+
+	return {
+		...stroke,
+		startTimestamp: now,
+		endTimestamp: 0,
+	};
+}
+
+export function appendPointToLastStroke(
+	paths: CanvasPath[],
+	point: Point,
+): CanvasPath[] {
+	const currentStroke = paths.slice(-1)[0];
+
+	if (!currentStroke) {
+		return paths;
+	}
+
+	const updatedStroke = {
+		...currentStroke,
+		paths: [...currentStroke.paths, point],
+	};
+
+	return [...paths.slice(0, -1), updatedStroke];
+}
+
+export function finishStroke(
+	paths: CanvasPath[],
+	withTimestamp: boolean,
+	now: number,
+): CanvasPath[] {
+	if (!withTimestamp) return paths;
+
+	const currentStroke = paths.slice(-1)?.[0] ?? null;
+	if (currentStroke === null) return paths;
+
+	const updatedStroke = {
+		...currentStroke,
+		endTimestamp: now,
+	};
+
+	return [...paths.slice(0, -1), updatedStroke];
+}
+```
+
+- [ ] **Step 3: Run stroke tests**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/react-sketch-canvas/strokes.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Write and implement sketching time tests**
+
+Create `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/sketchingTime.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { getSketchingTime } from "../../../src/ReactSketchCanvas/state/sketchingTime";
+
+describe("getSketchingTime", () => {
+	it("sums timestamp durations and treats missing timestamps as zero", () => {
+		expect(
+			getSketchingTime([
+				{
+					drawMode: true,
+					strokeColor: "red",
+					strokeWidth: 4,
+					paths: [{ x: 0, y: 0 }],
+					startTimestamp: 100,
+					endTimestamp: 250,
+				},
+				{
+					drawMode: true,
+					strokeColor: "blue",
+					strokeWidth: 4,
+					paths: [{ x: 1, y: 1 }],
+				},
+			]),
+		).toBe(150);
+	});
+});
+```
+
+Create `packages/react-sketch-canvas/src/ReactSketchCanvas/state/sketchingTime.ts`:
+
+```ts
+import type { CanvasPath } from "../../types";
+
+export function getSketchingTime(paths: CanvasPath[]): number {
+	return paths.reduce((totalSketchingTime, path) => {
+		const startTimestamp = path.startTimestamp ?? 0;
+		const endTimestamp = path.endTimestamp ?? 0;
+
+		return totalSketchingTime + (endTimestamp - startTimestamp);
+	}, 0);
+}
+```
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/react-sketch-canvas/sketchingTime.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write and implement history tests**
+
+Create `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/history.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { CanvasPath } from "../../../src/types";
+import {
+	addLastStrokeToHistory,
+	clearCanvasState,
+	createInitialSketchState,
+	loadPathsState,
+	redoState,
+	resetCanvasState,
+	undoState,
+} from "../../../src/ReactSketchCanvas/state/history";
+
+const path = (strokeColor: string): CanvasPath => ({
+	drawMode: true,
+	strokeColor,
+	strokeWidth: 4,
+	paths: [{ x: 0, y: 0 }],
+});
+
+describe("history state", () => {
+	it("adds the current paths to history only when unsynced", () => {
+		const state = {
+			...createInitialSketchState(),
+			currentPaths: [path("red")],
+			historyPos: 1,
+			historySynced: false,
+		};
+
+		expect(addLastStrokeToHistory(state).history).toEqual([[], [path("red")]]);
+		expect(addLastStrokeToHistory({ ...state, historySynced: true }).history).toEqual([
+			[],
+		]);
+	});
+
+	it("undoes and redoes through existing history", () => {
+		const state = {
+			...createInitialSketchState(),
+			history: [[], [path("red")], [path("red"), path("blue")]],
+			historyPos: 2,
+			currentPaths: [path("red"), path("blue")],
+			historySynced: true,
+		};
+
+		const undone = undoState(state);
+		expect(undone.currentPaths).toEqual([path("red")]);
+		expect(undone.historyPos).toBe(1);
+
+		const redone = redoState(undone);
+		expect(redone.currentPaths).toEqual([path("red"), path("blue")]);
+		expect(redone.historyPos).toBe(2);
+	});
+
+	it("clear appends an empty history entry", () => {
+		const state = {
+			...createInitialSketchState(),
+			currentPaths: [path("red")],
+			historyPos: 1,
+			historySynced: false,
+		};
+
+		const cleared = clearCanvasState(state);
+
+		expect(cleared.currentPaths).toEqual([]);
+		expect(cleared.history).toEqual([[], [path("red")], []]);
+		expect(cleared.historyPos).toBe(2);
+	});
+
+	it("loadPaths appends to current paths to preserve existing behavior", () => {
+		const loaded = loadPathsState(
+			{ ...createInitialSketchState(), currentPaths: [path("red")] },
+			[path("blue")],
+		);
+
+		expect(loaded.currentPaths).toEqual([path("red"), path("blue")]);
+	});
+
+	it("reset clears paths, history, and operation queue state", () => {
+		expect(resetCanvasState().history).toEqual([]);
+		expect(resetCanvasState().historyPos).toBe(0);
+		expect(resetCanvasState().currentPaths).toEqual([]);
+		expect(resetCanvasState().operationQueue).toEqual([]);
+	});
+});
+```
+
+Create `packages/react-sketch-canvas/src/ReactSketchCanvas/state/history.ts`:
+
+```ts
+import type { CanvasPath } from "../../types";
+import type { Operation } from "./operations";
+
+export type SketchState = {
+	drawMode: boolean;
+	isDrawing: boolean;
+	history: CanvasPath[][];
+	historyPos: number;
+	historySynced: boolean;
+	currentPaths: CanvasPath[];
+	operationQueue: Operation[];
+	isProcessingQueue: boolean;
+};
+
+export function createInitialSketchState(): SketchState {
+	return {
+		drawMode: true,
+		isDrawing: false,
+		history: [[]],
+		historyPos: 0,
+		historySynced: false,
+		currentPaths: [],
+		operationQueue: [],
+		isProcessingQueue: false,
+	};
+}
+
+export function addLastStrokeToHistory(state: SketchState): SketchState {
+	if (state.historySynced) return state;
+
+	return {
+		...state,
+		history: [
+			...state.history.slice(0, state.historyPos),
+			[...state.currentPaths],
+		],
+		historySynced: true,
+	};
+}
+
+export function undoState(state: SketchState): SketchState {
+	if (state.historyPos <= 0) return state;
+	const synced = addLastStrokeToHistory(state);
+
+	return {
+		...synced,
+		currentPaths: synced.history[synced.historyPos - 1],
+		historyPos: synced.historyPos - 1,
+	};
+}
+
+export function redoState(state: SketchState): SketchState {
+	if (state.historyPos >= state.history.length - 1) return state;
+	const synced = addLastStrokeToHistory(state);
+
+	return {
+		...synced,
+		currentPaths: synced.history[synced.historyPos + 1],
+		historyPos: synced.historyPos + 1,
+	};
+}
+
+export function clearCanvasState(state: SketchState): SketchState {
+	const synced = addLastStrokeToHistory(state);
+
+	return {
+		...synced,
+		currentPaths: [],
+		history: [...synced.history.slice(0, synced.historyPos + 1), []],
+		historyPos: synced.historyPos + 1,
+	};
+}
+
+export function loadPathsState(
+	state: SketchState,
+	paths: CanvasPath[],
+): SketchState {
+	const synced = addLastStrokeToHistory(state);
+	const newPaths = [...synced.currentPaths, ...paths];
+	const newHistoryPos = synced.historyPos + 1;
+
+	return {
+		...synced,
+		currentPaths: newPaths,
+		history: [...synced.history.slice(0, newHistoryPos), newPaths],
+		historyPos: newHistoryPos,
+	};
+}
+
+export function resetCanvasState(): SketchState {
+	return {
+		...createInitialSketchState(),
+		history: [],
+	};
+}
+```
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/react-sketch-canvas/history.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Write and implement operation tests**
+
+Create `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/operations.spec.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { CanvasPath } from "../../../src/types";
+import { createInitialSketchState } from "../../../src/ReactSketchCanvas/state/history";
+import {
+	applyOperation,
+	enqueueOperation,
+} from "../../../src/ReactSketchCanvas/state/operations";
+
+const path = (strokeColor: string): CanvasPath => ({
+	drawMode: true,
+	strokeColor,
+	strokeWidth: 4,
+	paths: [{ x: 0, y: 0 }],
+});
+
+describe("operations", () => {
+	it("enqueues operations in order", () => {
+		expect(
+			enqueueOperation(createInitialSketchState(), { type: "clear" }).operationQueue,
+		).toEqual([{ type: "clear" }]);
+	});
+
+	it("applies loadPaths operation", () => {
+		const next = applyOperation(createInitialSketchState(), {
+			type: "loadPaths",
+			payload: [path("red")],
+		});
+
+		expect(next.currentPaths).toEqual([path("red")]);
+	});
+
+	it("throws on unknown operations", () => {
+		expect(() =>
+			applyOperation(createInitialSketchState(), { type: "unknown" } as never),
+		).toThrow("Unknown operation type: unknown");
+	});
+});
+```
+
+Create `packages/react-sketch-canvas/src/ReactSketchCanvas/state/operations.ts`:
+
+```ts
+import type { CanvasPath } from "../../types";
+import type { SketchState } from "./history";
+import {
+	clearCanvasState,
+	loadPathsState,
+	redoState,
+	undoState,
+} from "./history";
+
+export type Operation = {
+	type: "undo" | "redo" | "clear" | "loadPaths";
+	payload?: CanvasPath[];
+};
+
+export function enqueueOperation(
+	state: SketchState,
+	operation: Operation,
+): SketchState {
+	return {
+		...state,
+		operationQueue: [...state.operationQueue, operation],
+	};
+}
+
+export function applyOperation(
+	state: SketchState,
+	operation: Operation,
+): SketchState {
+	switch (operation.type) {
+		case "undo":
+			return undoState(state);
+		case "redo":
+			return redoState(state);
+		case "clear":
+			return clearCanvasState(state);
+		case "loadPaths":
+			return operation.payload ? loadPathsState(state, operation.payload) : state;
+		default:
+			throw new Error(`Unknown operation type: ${(operation as Operation).type}`);
+	}
+}
+```
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/react-sketch-canvas/operations.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run all new state tests**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/react-sketch-canvas
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit state extraction**
+
+Run:
+
+```bash
+git add packages/react-sketch-canvas/src/ReactSketchCanvas/state packages/react-sketch-canvas/tests/unit/react-sketch-canvas
+git commit -m "refactor: extract sketch canvas state logic"
+```
+
+Expected: conventional commit succeeds.
+
+---
+
+## Task 7: Introduce ReactSketchCanvas Controller And Imperative Hooks
+
+**Files:**
+
+- Create: `packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts`
+- Create: `packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasImperativeHandle.ts`
+- Modify: `packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx`
+- Create: `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasController.spec.tsx`
+- Create: `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasImperativeHandle.spec.tsx`
+
+- [ ] **Step 1: Write controller hook tests**
+
+Create `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasController.spec.tsx`:
+
+```tsx
+import { act, render } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useSketchCanvasController } from "../../../src/ReactSketchCanvas/hooks/useSketchCanvasController";
+import type { CanvasPath, Point } from "../../../src/types";
+
+type ControllerSnapshot = ReturnType<typeof useSketchCanvasController>;
+
+function Harness({
+	onReady,
+	onChange = vi.fn(),
+	onStroke = vi.fn(),
+}: {
+	onReady: (controller: ControllerSnapshot) => void;
+	onChange?: (paths: CanvasPath[]) => void;
+	onStroke?: (path: CanvasPath, isEraser: boolean) => void;
+}) {
+	const controller = useSketchCanvasController({
+		strokeColor: "red",
+		strokeWidth: 4,
+		eraserWidth: 8,
+		withTimestamp: false,
+		onChange,
+		onStroke,
+	});
+
+	React.useEffect(() => {
+		onReady(controller);
+	}, [controller, onReady]);
+
+	return null;
+}
+
+describe("useSketchCanvasController", () => {
+	it("creates and extends a stroke from pointer events", () => {
+		let controller: ControllerSnapshot | undefined;
+		const onReady = vi.fn((next: ControllerSnapshot) => {
+			controller = next;
+		});
+
+		render(<Harness onReady={onReady} />);
+
+		act(() => {
+			controller?.handlePointerDown({ x: 1, y: 2 } satisfies Point);
+		});
+		act(() => {
+			controller?.handlePointerMove({ x: 3, y: 4 } satisfies Point);
+		});
+
+		expect(controller?.currentPaths).toEqual([
+			{
+				drawMode: true,
+				strokeColor: "red",
+				strokeWidth: 4,
+				paths: [
+					{ x: 1, y: 2 },
+					{ x: 3, y: 4 },
+				],
+			},
+		]);
+	});
+
+	it("uses eraser stroke settings for eraser input", () => {
+		let controller: ControllerSnapshot | undefined;
+		render(
+			<Harness
+				onReady={(next) => {
+					controller = next;
+				}}
+			/>,
+		);
+
+		act(() => {
+			controller?.handlePointerDown({ x: 1, y: 2 }, true);
+		});
+
+		expect(controller?.currentPaths[0]).toMatchObject({
+			drawMode: false,
+			strokeColor: "#000000",
+			strokeWidth: 8,
+		});
+	});
+});
+```
+
+- [ ] **Step 2: Create controller hook**
+
+Create `packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts`:
+
+```ts
+import * as React from "react";
+import { useCallback } from "react";
+import type { CanvasPath, Point } from "../../types";
+import {
+	addLastStrokeToHistory,
+	createInitialSketchState,
+	type SketchState,
+} from "../state/history";
+import {
+	applyOperation,
+	enqueueOperation as enqueueOperationInState,
+	type Operation,
+} from "../state/operations";
+import {
+	appendPointToLastStroke,
+	createStroke,
+	finishStroke,
+} from "../state/strokes";
+
+type UseSketchCanvasControllerOptions = {
+	strokeColor: string;
+	strokeWidth: number;
+	eraserWidth: number;
+	withTimestamp: boolean;
+	onChange: (updatedPaths: CanvasPath[]) => void;
+	onStroke: (path: CanvasPath, isEraser: boolean) => void;
+};
+
+export function useSketchCanvasController({
+	strokeColor,
+	strokeWidth,
+	eraserWidth,
+	withTimestamp,
+	onChange,
+	onStroke,
+}: UseSketchCanvasControllerOptions) {
+	const [state, setState] = React.useState<SketchState>(createInitialSketchState);
+
+	const currentPaths = state.currentPaths;
+	const isDrawing = state.isDrawing;
+	const drawMode = state.drawMode;
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: preserve legacy stroke-lift timing tied only to drawing state changes.
+	const liftStrokeUp = React.useCallback((): void => {
+		const lastStroke = currentPaths.slice(-1)?.[0] ?? null;
+		if (lastStroke === null) return;
+
+		onStroke(lastStroke, !lastStroke.drawMode);
+	}, [isDrawing]);
+
+	React.useEffect(() => {
+		liftStrokeUp();
+	}, [liftStrokeUp]);
+
+	React.useEffect(() => {
+		onChange(currentPaths);
+	}, [currentPaths, onChange]);
+
+	React.useEffect(() => {
+		if (state.isProcessingQueue || state.operationQueue.length === 0) return;
+
+		setState((current) => {
+			if (current.isProcessingQueue || current.operationQueue.length === 0) {
+				return current;
+			}
+
+			const [operation, ...remainingQueue] = current.operationQueue;
+			const processed = applyOperation(
+				{ ...current, isProcessingQueue: true },
+				operation,
+			);
+
+			return {
+				...processed,
+				operationQueue: remainingQueue,
+				isProcessingQueue: false,
+			};
+		});
+	}, [state.isProcessingQueue, state.operationQueue]);
+
+	const enqueueOperation = useCallback((operation: Operation) => {
+		setState((current) => enqueueOperationInState(current, operation));
+	}, []);
+
+	const setEraseMode = useCallback((erase: boolean): void => {
+		setState((current) => ({ ...current, drawMode: !erase }));
+	}, []);
+
+	const resetCanvas = useCallback((): void => {
+		setState({
+			...createInitialSketchState(),
+			history: [],
+		});
+	}, []);
+
+	const handlePointerDown = useCallback(
+		(point: Point, isEraser = false): void => {
+			setState((current) => {
+				const synced = addLastStrokeToHistory(current);
+				const isDraw = !isEraser && synced.drawMode;
+				const stroke = createStroke({
+					point,
+					drawMode: isDraw,
+					strokeColor,
+					strokeWidth,
+					eraserWidth,
+					withTimestamp,
+					now: Date.now(),
+				});
+
+				return {
+					...synced,
+					isDrawing: true,
+					historyPos: synced.historyPos + 1,
+					historySynced: false,
+					currentPaths: [...synced.currentPaths, stroke],
+				};
+			});
+		},
+		[eraserWidth, strokeColor, strokeWidth, withTimestamp],
+	);
+
+	const handlePointerMove = useCallback((point: Point): void => {
+		setState((current) => {
+			if (!current.isDrawing) return current;
+
+			return {
+				...current,
+				currentPaths: appendPointToLastStroke(current.currentPaths, point),
+			};
+		});
+	}, []);
+
+	const handlePointerUp = useCallback((): void => {
+		setState((current) => {
+			if (!current.isDrawing) return current;
+
+			return {
+				...current,
+				isDrawing: false,
+				currentPaths: finishStroke(current.currentPaths, withTimestamp, Date.now()),
+			};
+		});
+	}, [withTimestamp]);
+
+	return {
+		currentPaths,
+		isDrawing,
+		drawMode,
+		setEraseMode,
+		enqueueOperation,
+		resetCanvas,
+		handlePointerDown,
+		handlePointerMove,
+		handlePointerUp,
+	};
+}
+```
+
+- [ ] **Step 3: Run controller hook tests**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/react-sketch-canvas/useSketchCanvasController.spec.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Write imperative hook tests**
+
+Create `packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasImperativeHandle.spec.tsx`:
+
+```tsx
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { CanvasRef } from "../../../src/Canvas/types";
+import { useSketchCanvasImperativeHandle } from "../../../src/ReactSketchCanvas/hooks/useSketchCanvasImperativeHandle";
+import type { ReactSketchCanvasRef } from "../../../src/ReactSketchCanvas/types";
+import type { CanvasPath } from "../../../src/types";
+
+const path: CanvasPath = {
+	drawMode: true,
+	strokeColor: "red",
+	strokeWidth: 4,
+	paths: [{ x: 0, y: 0 }],
+	startTimestamp: 10,
+	endTimestamp: 30,
+};
+
+const canvasApi: CanvasRef = {
+	exportImage: vi.fn(async () => "data:image/png;base64,abc"),
+	exportSvg: vi.fn(async () => "<svg></svg>"),
+};
+
+function Harness({
+	forwardedRef,
+	withTimestamp = true,
+}: {
+	forwardedRef: React.RefObject<ReactSketchCanvasRef>;
+	withTimestamp?: boolean;
+}) {
+	const canvasRef = React.useRef<CanvasRef>(canvasApi);
+	useSketchCanvasImperativeHandle(forwardedRef, {
+		canvasRef,
+		currentPaths: [path],
+		withTimestamp,
+		setEraseMode: vi.fn(),
+		enqueueOperation: vi.fn(),
+		resetCanvas: vi.fn(),
+	});
+	return null;
+}
+
+describe("useSketchCanvasImperativeHandle", () => {
+	it("exposes export methods and current paths", async () => {
+		const ref = React.createRef<ReactSketchCanvasRef>();
+		render(<Harness forwardedRef={ref} />);
+
+		await expect(ref.current?.exportImage("png")).resolves.toBe(
+			"data:image/png;base64,abc",
+		);
+		await expect(ref.current?.exportSvg()).resolves.toBe("<svg></svg>");
+		await expect(ref.current?.exportPaths()).resolves.toEqual([path]);
+		await expect(ref.current?.getSketchingTime()).resolves.toBe(20);
+	});
+
+	it("rejects sketching time when timestamps are disabled", async () => {
+		const ref = React.createRef<ReactSketchCanvasRef>();
+		render(<Harness forwardedRef={ref} withTimestamp={false} />);
+
+		await expect(ref.current?.getSketchingTime()).rejects.toThrow(
+			"Set 'withTimestamp' prop to get sketching time",
+		);
+	});
+});
+```
+
+- [ ] **Step 5: Create imperative hook**
+
+Create `packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasImperativeHandle.ts`:
+
+```ts
+import * as React from "react";
+import type { CanvasRef } from "../../Canvas/types";
+import type { CanvasPath, ExportImageOptions, ExportImageType } from "../../types";
+import type { ReactSketchCanvasRef } from "../types";
+import type { Operation } from "../state/operations";
+import { getSketchingTime } from "../state/sketchingTime";
+
+type UseSketchCanvasImperativeHandleOptions = {
+	canvasRef: React.RefObject<CanvasRef>;
+	currentPaths: CanvasPath[];
+	withTimestamp: boolean;
+	setEraseMode: (erase: boolean) => void;
+	enqueueOperation: (operation: Operation) => void;
+	resetCanvas: () => void;
+};
+
+export function useSketchCanvasImperativeHandle(
+	ref: React.ForwardedRef<ReactSketchCanvasRef>,
+	{
+		canvasRef,
+		currentPaths,
+		withTimestamp,
+		setEraseMode,
+		enqueueOperation,
+		resetCanvas,
+	}: UseSketchCanvasImperativeHandleOptions,
+): void {
+	React.useImperativeHandle(
+		ref,
+		() => ({
+			eraseMode: setEraseMode,
+			clearCanvas: (): void => {
+				enqueueOperation({ type: "clear" });
+			},
+			undo: (): void => {
+				enqueueOperation({ type: "undo" });
+			},
+			redo: (): void => {
+				enqueueOperation({ type: "redo" });
+			},
+			exportImage: (
+				imageType: ExportImageType,
+				options?: ExportImageOptions,
+			): Promise<string> => {
+				const exportImage = canvasRef.current?.exportImage;
+
+				if (!exportImage) {
+					throw Error("Export function called before canvas loaded");
+				}
+
+				return exportImage(imageType, options);
+			},
+			exportSvg: async (): Promise<string> => {
+				const exportSvg = canvasRef.current?.exportSvg;
+
+				if (!exportSvg) {
+					throw Error("Export function called before canvas loaded");
+				}
+
+				return exportSvg();
+			},
+			exportPaths: async (): Promise<CanvasPath[]> => currentPaths,
+			loadPaths: (paths: CanvasPath[]): void => {
+				enqueueOperation({ type: "loadPaths", payload: paths });
+			},
+			getSketchingTime: async (): Promise<number> => {
+				if (!withTimestamp) {
+					throw new Error("Set 'withTimestamp' prop to get sketching time");
+				}
+
+				return getSketchingTime(currentPaths);
+			},
+			resetCanvas,
+		}),
+		[
+			canvasRef,
+			currentPaths,
+			enqueueOperation,
+			resetCanvas,
+			setEraseMode,
+			withTimestamp,
+		],
+	);
+}
+```
+
+- [ ] **Step 6: Run imperative hook tests**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas exec vitest run tests/unit/react-sketch-canvas/useSketchCanvasImperativeHandle.spec.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Wire hooks into ReactSketchCanvas**
+
+Replace the stateful internals of `packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx` while preserving prop defaults and the final `<Canvas />` props.
+
+At the top, keep:
+
+```ts
+import * as React from "react";
+import { Canvas } from "../Canvas";
+import type { CanvasRef } from "../Canvas/types";
+import type { ReactSketchCanvasProps, ReactSketchCanvasRef } from "./types";
+import { useSketchCanvasController } from "./hooks/useSketchCanvasController";
+import { useSketchCanvasImperativeHandle } from "./hooks/useSketchCanvasImperativeHandle";
+```
+
+Inside the component, after prop defaults, use:
+
+```ts
+const svgCanvas = React.createRef<CanvasRef>();
+const {
+	currentPaths,
+	isDrawing,
+	enqueueOperation,
+	resetCanvas,
+	setEraseMode,
+	handlePointerDown,
+	handlePointerMove,
+	handlePointerUp,
+} = useSketchCanvasController({
+	strokeColor,
+	strokeWidth,
+	eraserWidth,
+	withTimestamp,
+	onChange,
+	onStroke,
+});
+
+useSketchCanvasImperativeHandle(ref, {
+	canvasRef: svgCanvas,
+	currentPaths,
+	withTimestamp,
+	setEraseMode,
+	enqueueOperation,
+	resetCanvas,
+});
+```
+
+Render `Canvas` with the same public props as before:
+
+```tsx
+return (
+	<Canvas
+		ref={svgCanvas}
+		id={id}
+		width={width}
+		height={height}
+		className={className}
+		canvasColor={canvasColor}
+		backgroundImage={backgroundImage}
+		exportWithBackgroundImage={exportWithBackgroundImage}
+		preserveBackgroundImageAspectRatio={preserveBackgroundImageAspectRatio}
+		allowOnlyPointerType={allowOnlyPointerType}
+		style={style}
+		svgStyle={svgStyle}
+		paths={currentPaths}
+		isDrawing={isDrawing}
+		onPointerDown={handlePointerDown}
+		onPointerMove={handlePointerMove}
+		onPointerUp={handlePointerUp}
+		withViewBox={withViewBox}
+		readOnly={readOnly}
+	/>
+);
+```
+
+- [ ] **Step 8: Run unit tests and action tests**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas test:unit
+pnpm --filter react-sketch-canvas test:ct -- tests/actions/undoRedo.spec.tsx tests/actions/import.spec.tsx tests/actions/erase.spec.tsx
+```
+
+Expected: PASS. These tests guard imperative ref behavior, operation sequencing, load paths, undo/redo, and eraser mode.
+
+- [ ] **Step 9: Commit ReactSketchCanvas hook extraction**
+
+Run:
+
+```bash
+git add packages/react-sketch-canvas/src/ReactSketchCanvas packages/react-sketch-canvas/tests/unit/react-sketch-canvas
+git commit -m "refactor: extract sketch canvas controller hooks"
+```
+
+Expected: conventional commit succeeds.
+
+---
+
+## Task 8: Thin Canvas Index And Remove Dead Imports
+
+**Files:**
+
+- Modify: `packages/react-sketch-canvas/src/Canvas/index.tsx`
+- Modify: `packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx`
+- Modify: `packages/react-sketch-canvas/src/Paths/index.tsx`
+
+- [ ] **Step 1: Inspect file sizes and unused imports**
+
+Run:
+
+```bash
+wc -l packages/react-sketch-canvas/src/Canvas/index.tsx packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx packages/react-sketch-canvas/src/Paths/index.tsx
+pnpm --filter react-sketch-canvas lint
+```
+
+Expected: lint identifies no unused imports. The three index files should be substantially smaller than the starting point: `Canvas/index.tsx` under 160 lines, `ReactSketchCanvas/index.tsx` under 140 lines, and `Paths/index.tsx` under 50 lines.
+
+- [ ] **Step 2: Simplify Canvas imports and body**
+
+Ensure `packages/react-sketch-canvas/src/Canvas/index.tsx` imports only:
+
+```ts
+import * as React from "react";
+import { CanvasSvg } from "./svg/CanvasSvg";
+import { useCanvasExportHandle } from "./hooks/useCanvasExportHandle";
+import { useCanvasPointerHandlers } from "./hooks/useCanvasPointerHandlers";
+import type { CanvasProps, CanvasRef } from "./types";
+```
+
+The component body should only:
+
+- Apply prop defaults.
+- Create `canvasRef` and `canvasSizeRef`.
+- Call `useCanvasExportHandle`.
+- Call `useCanvasPointerHandlers`.
+- Compute `viewBox`.
+- Render wrapper `div` and `CanvasSvg`.
+
+- [ ] **Step 3: Simplify ReactSketchCanvas imports and body**
+
+Ensure `packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx` imports only:
+
+```ts
+import * as React from "react";
+import { Canvas } from "../Canvas";
+import type { CanvasRef } from "../Canvas/types";
+import { useSketchCanvasController } from "./hooks/useSketchCanvasController";
+import { useSketchCanvasImperativeHandle } from "./hooks/useSketchCanvasImperativeHandle";
+import type { ReactSketchCanvasProps, ReactSketchCanvasRef } from "./types";
+```
+
+The component body should only:
+
+- Apply prop defaults.
+- Create the `CanvasRef`.
+- Call `useSketchCanvasController`.
+- Call `useSketchCanvasImperativeHandle`.
+- Render `Canvas`.
+
+- [ ] **Step 4: Run unit tests and lint**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas test:unit
+pnpm --filter react-sketch-canvas lint
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 5: Commit index cleanup**
+
+Run:
+
+```bash
+git add packages/react-sketch-canvas/src/Canvas/index.tsx packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx packages/react-sketch-canvas/src/Paths/index.tsx
+git commit -m "refactor: thin public component adapters"
+```
+
+Expected: conventional commit succeeds.
+
+---
+
+## Task 9: Full Behavior Verification
+
+**Files:**
+
+- Read: all modified files from Tasks 2-8.
+
+- [ ] **Step 1: Run full unit test suite**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas test:unit
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full Playwright component suite**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas test:ct
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full Playwright e2e suite**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas test:e2e
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run package build**
+
+Run:
+
+```bash
+pnpm --filter react-sketch-canvas build
+```
+
+Expected: PASS and `packages/react-sketch-canvas/dist/` is generated.
+
+- [ ] **Step 5: Run repo lint**
+
+Run:
+
+```bash
+pnpm lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Check public exports did not change**
+
+Run:
+
+```bash
+git diff -- packages/react-sketch-canvas/src/index.tsx packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts packages/react-sketch-canvas/src/Canvas/types.ts packages/react-sketch-canvas/src/types
+```
+
+Expected: no uncommitted public type/API changes unless they are import-only or internal comment changes. Also review the commits made in Tasks 2-8 for these same files; if public types changed, stop and review with the user before proceeding.
+
+- [ ] **Step 7: Inspect final file sizes**
+
+Run:
+
+```bash
+wc -l packages/react-sketch-canvas/src/Canvas/index.tsx packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx packages/react-sketch-canvas/src/Paths/index.tsx packages/react-sketch-canvas/src/Canvas/**/*.ts packages/react-sketch-canvas/src/Canvas/**/*.tsx packages/react-sketch-canvas/src/ReactSketchCanvas/**/*.ts packages/react-sketch-canvas/src/ReactSketchCanvas/**/*.tsx packages/react-sketch-canvas/src/Paths/**/*.ts packages/react-sketch-canvas/src/Paths/**/*.tsx
+```
+
+Expected: the old large index files are split into focused modules. No newly created source file should be larger than 220 lines unless there is a clear reason documented in the final response.
+
+- [ ] **Step 8: Commit verification-only fixes if needed**
+
+If verification required small internal fixes, commit them:
+
+```bash
+git add packages/react-sketch-canvas/src packages/react-sketch-canvas/tests/unit
+git commit -m "test: verify source architecture refactor"
+```
+
+Expected: commit only if files changed after Task 8. If no files changed, do not create an empty commit.
+
+---
+
+## Final Notes For Execution
+
+- Keep all commits conventional.
+- Keep public API and behavior stable.
+- If a test exposes a current behavior mismatch, add characterization coverage and ask before changing semantics.
+- Prefer pure function tests over hook tests when both can cover the same rule.
+- Hook tests should use Testing Library harness components and assert consumer-visible behavior.
+- Do not broaden this into CI, docs, packaging, or release changes.

--- a/docs/superpowers/specs/2026-05-17-src-architecture-refactor-design.md
+++ b/docs/superpowers/specs/2026-05-17-src-architecture-refactor-design.md
@@ -1,0 +1,235 @@
+# React Sketch Canvas Source Architecture Refactor Design
+
+Date: 2026-05-17
+
+## Goal
+
+Refactor the `packages/react-sketch-canvas/src` implementation so the package internals are easier to read, reason about, and unit test. The current source concentrates drawing state, history behavior, pointer handling, SVG rendering, eraser mask construction, and export behavior inside a few large files. This design splits those responsibilities into focused modules while preserving the existing public API and runtime behavior.
+
+This refactor is architecture-only from a consumer perspective. Public component names, package entrypoints, props, ref methods, drawing semantics, export semantics, and documented usage stay stable. If implementation work exposes a bug or a public behavior conflict, pause and discuss before changing public API or behavior.
+
+## Current Shape
+
+The implementation is concentrated in:
+
+- `src/ReactSketchCanvas/index.tsx`: public component wrapper, draw/erase mode, drawing lifecycle, undo/redo history, operation queueing, timestamp handling, callbacks, and imperative ref methods.
+- `src/Canvas/index.tsx`: DOM wrapper, pointer event filtering, coordinate calculation, export image/SVG methods, background rendering, path grouping, eraser mask generation, and SVG rendering.
+- `src/Paths/index.tsx`: path geometry helpers and React SVG path rendering.
+
+This makes the code harder to scan and pushes many behaviors into React component tests even when the logic could be tested as pure functions.
+
+## Target Architecture
+
+Keep the package entrypoint stable, but reorganize internals around responsibility boundaries:
+
+```text
+src/
+  ReactSketchCanvas/
+    index.tsx
+    types.ts
+    hooks/
+      useSketchCanvasController.ts
+      useSketchCanvasImperativeHandle.ts
+    state/
+      history.ts
+      operations.ts
+      strokes.ts
+      sketchingTime.ts
+  Canvas/
+    index.tsx
+    types.ts
+    hooks/
+      useCanvasPointerHandlers.ts
+      useCanvasExportHandle.ts
+    export/
+      image.ts
+      svg.ts
+      dom.ts
+    svg/
+      CanvasSvg.tsx
+      Background.tsx
+      EraserMasks.tsx
+      StrokeGroups.tsx
+      grouping.ts
+  Paths/
+    index.tsx
+    SvgPath.tsx
+    geometry.ts
+```
+
+`ReactSketchCanvas/index.tsx` becomes a thin adapter that applies prop defaults, uses the sketch controller, exposes the public imperative ref, and renders `Canvas`.
+
+`Canvas/index.tsx` becomes a thin DOM container that owns the wrapper ref, wires pointer handlers, exposes export methods, and renders `CanvasSvg`.
+
+`Paths/index.tsx` remains the public local barrel for path rendering helpers, but geometry moves into a pure module and `SvgPath` moves into its own component file.
+
+## Responsibility Boundaries
+
+### ReactSketchCanvas State
+
+The `ReactSketchCanvas/state` modules own drawing state transitions and operations:
+
+- `history.ts`: undo, redo, clear, reset, load paths, history position, and history synchronization behavior.
+- `operations.ts`: operation types and queue application semantics if the queue abstraction remains necessary.
+- `strokes.ts`: create a new stroke, append points to the active stroke, finish a stroke, and apply timestamp fields.
+- `sketchingTime.ts`: calculate total sketching duration from timestamped paths.
+
+These modules should be pure functions wherever possible. They should not import React, DOM APIs, or component files.
+
+### ReactSketchCanvas Hooks
+
+The `ReactSketchCanvas/hooks` modules bridge pure state logic into React:
+
+- `useSketchCanvasController.ts`: owns React state, callback timing, drawing lifecycle handlers, and operation dispatching.
+- `useSketchCanvasImperativeHandle.ts`: builds the public `ReactSketchCanvasRef` methods from controller state/actions and the lower-level `CanvasRef`.
+
+Hooks may use React state, effects, refs, and callbacks, but should delegate business rules to the pure state modules.
+
+### Canvas Pointer And Export
+
+The `Canvas/hooks` and `Canvas/export` modules own DOM-specific behavior:
+
+- `useCanvasPointerHandlers.ts`: filters pointer type, ignores non-primary mouse buttons, detects pen eraser button state, converts events into canvas-relative points, and connects document-level `pointerup`.
+- `useCanvasExportHandle.ts`: exposes the lower-level `CanvasRef` by composing SVG and image export helpers.
+- `export/dom.ts`: clone the SVG canvas, apply dimensions/viewBox, and provide DOM utilities needed by export.
+- `export/svg.ts`: prepare exported SVG strings, including background removal/fill behavior.
+- `export/image.ts`: load images, compose render canvas output, apply JPEG background fill, and honor requested export dimensions.
+
+DOM and browser image behavior may still need Playwright coverage, but option handling and string/DOM transformations should be unit tested where practical.
+
+### Canvas SVG Rendering
+
+The `Canvas/svg` modules own presentational SVG structure:
+
+- `CanvasSvg.tsx`: top-level SVG composition.
+- `Background.tsx`: background rect and optional background image pattern.
+- `EraserMasks.tsx`: hidden eraser strokes and mask definitions.
+- `StrokeGroups.tsx`: grouped draw strokes with mask references.
+- `grouping.ts`: pure grouping helpers for draw paths and eraser paths.
+
+The rendering components should stay mostly declarative. Grouping and ID construction rules should be extracted enough to unit test without rendering the full canvas.
+
+### Paths
+
+The `Paths` modules separate geometry from rendering:
+
+- `geometry.ts`: line measurement, control point calculation, and bezier command generation.
+- `SvgPath.tsx`: render a circle for single-point strokes and a path for multi-point strokes.
+- `index.tsx`: keep existing local exports and default `Paths` component behavior.
+
+## Data Flow
+
+The user-visible drawing flow remains unchanged:
+
+1. `Canvas` receives DOM pointer events.
+2. Pointer helpers reject disallowed pointer types, ignore non-primary mouse buttons, detect pen eraser button state, and convert DOM coordinates into canvas-relative points.
+3. `ReactSketchCanvas` receives normalized drawing events.
+4. The sketch controller creates or updates `CanvasPath` records.
+5. The canvas renders current paths through grouped SVG strokes and eraser masks.
+6. Imperative methods continue to operate through `ReactSketchCanvasRef` and `CanvasRef`.
+
+Internal state transitions become explicit functions. Examples:
+
+- `beginStroke(state, point, options)` returns the next state with a new stroke.
+- `appendPoint(state, point)` returns the next state with the active stroke extended.
+- `endStroke(state, now)` returns the next state with drawing stopped and optional timestamp completed.
+- `applyOperation(state, operation)` applies undo, redo, clear, load, or reset semantics.
+
+Exact function names can change during implementation if the final names are clearer, but the design goal is stable: pure transitions first, React orchestration second, rendering third.
+
+## Behavior Preservation
+
+Preserve existing behavior unless the user explicitly approves a change. Important behavior to characterize with tests before or during extraction:
+
+- Undo/redo history position and history synchronization.
+- `loadPaths` currently appends paths to existing paths even though the type comment says it replaces them. Preserve the implementation behavior for this refactor.
+- `onChange` timing after path changes.
+- `onStroke` timing after drawing ends.
+- Timestamp start and end behavior when `withTimestamp` is enabled.
+- Read-only pointer behavior.
+- Eraser mode and pen eraser button override.
+- Pointer type filtering.
+- SVG export behavior with and without background image.
+- JPEG canvas fill behavior when exporting without background image.
+- Eraser path grouping and mask references.
+- Single-point and multi-point path rendering.
+
+If a behavior appears wrong but is currently observable, add a characterization test and discuss before changing it.
+
+## Testing Strategy
+
+Move more coverage into Vitest while keeping Playwright as the browser-visible behavior backstop.
+
+Proposed unit test shape:
+
+```text
+tests/unit/
+  react-sketch-canvas/
+    history.spec.ts
+    operations.spec.ts
+    strokes.spec.ts
+    sketchingTime.spec.ts
+    useSketchCanvasController.spec.tsx
+    useSketchCanvasImperativeHandle.spec.tsx
+  canvas/
+    pointer.spec.ts
+    grouping.spec.ts
+    svgExport.spec.ts
+    useCanvasPointerHandlers.spec.tsx
+    useCanvasExportHandle.spec.tsx
+  paths/
+    geometry.spec.ts
+    SvgPath.spec.tsx
+```
+
+Pure module tests should be table-driven where useful and should avoid React rendering. These tests should cover the detailed state matrix for history, operations, strokes, grouping, geometry, and sketching-time calculation.
+
+Hook tests should use Testing Library with small harness components. They should verify hook inputs, outputs, callback wiring, effect timing, refs, and consumer-visible integration. They should not test private implementation details or duplicate every pure transition case already covered by state module tests.
+
+Existing Playwright component and e2e tests stay in place and should pass unchanged. Playwright remains responsible for pointer physics, browser SVG behavior, canvas image export behavior, and user-visible interaction contracts.
+
+## Implementation Order
+
+The implementation should be staged to preserve reviewability while still completing the full refactor in one cycle:
+
+1. Extract `Paths` geometry and `SvgPath` with unit tests.
+2. Extract canvas SVG grouping and presentational SVG components with unit tests.
+3. Extract canvas pointer helpers and export helpers with unit and hook tests.
+4. Extract `ReactSketchCanvas` pure state modules with characterization unit tests.
+5. Introduce `ReactSketchCanvas` hooks and hook tests using Testing Library harnesses.
+6. Thin down `ReactSketchCanvas/index.tsx` and `Canvas/index.tsx`.
+7. Run full verification and adjust only internal seams needed for stability.
+
+Each step should keep tests passing before moving deeper into the next responsibility area.
+
+## Verification
+
+Run these commands before considering the refactor complete:
+
+```bash
+pnpm --filter react-sketch-canvas test:unit
+pnpm --filter react-sketch-canvas test:ct
+pnpm --filter react-sketch-canvas test:e2e
+pnpm --filter react-sketch-canvas build
+pnpm lint
+```
+
+If one command cannot run in the local environment, document the exact failure and the remaining risk.
+
+## Out Of Scope
+
+- Public API redesign.
+- Changing component names, prop names, ref method names, or package exports.
+- Changing drawing semantics, eraser semantics, export output semantics, or callback timing intentionally.
+- Rewriting the docs app.
+- Replacing SVG rendering with canvas or another rendering backend.
+- Broad packaging, CI, or repository modernization unrelated to the `src` architecture.
+
+## Success Criteria
+
+- `ReactSketchCanvas/index.tsx`, `Canvas/index.tsx`, and `Paths/index.tsx` become small composition files.
+- Drawing state, history, operations, grouping, geometry, and export preparation are testable without rendering full React components.
+- Hooks have focused Testing Library coverage through harness components.
+- Existing Playwright behavior tests still pass.
+- Public API and documented usage remain stable.
+- The source layout communicates each module's purpose without needing to read unrelated implementation details.

--- a/packages/react-sketch-canvas/src/Canvas/export/dom.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/dom.ts
@@ -1,0 +1,11 @@
+export function getCanvasWithViewBox(canvas: HTMLDivElement) {
+	const svgCanvas = canvas.firstChild?.cloneNode(true) as SVGElement;
+	const width = canvas.offsetWidth;
+	const height = canvas.offsetHeight;
+
+	svgCanvas.setAttribute("viewBox", `0 0 ${width} ${height}`);
+	svgCanvas.setAttribute("width", width.toString());
+	svgCanvas.setAttribute("height", height.toString());
+
+	return { svgCanvas, width, height };
+}

--- a/packages/react-sketch-canvas/src/Canvas/export/dom.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/dom.ts
@@ -1,4 +1,20 @@
-export function getCanvasWithViewBox(canvas: HTMLDivElement) {
+type GetCanvasWithViewBoxReturns = {
+	svgCanvas: SVGElement;
+	width: number;
+	height: number;
+};
+
+/**
+ * Clone the rendered SVG and stamp it with the wrapper dimensions.
+ *
+ * @remarks
+ * Export code works on a clone so callers can export without mutating the live
+ * canvas. Width, height, and viewBox are normalized from the wrapper element to
+ * make exported SVG and raster output match the rendered canvas size.
+ */
+export function getCanvasWithViewBox(
+	canvas: HTMLDivElement,
+): GetCanvasWithViewBoxReturns {
 	const svgCanvas = canvas.firstChild?.cloneNode(true) as SVGElement;
 	const width = canvas.offsetWidth;
 	const height = canvas.offsetHeight;

--- a/packages/react-sketch-canvas/src/Canvas/export/image.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/image.ts
@@ -1,0 +1,74 @@
+import type { ExportImageOptions, ExportImageType } from "../../types";
+
+export const loadImage = (url: string): Promise<HTMLImageElement> =>
+	new Promise((resolve, reject) => {
+		const img = new Image();
+		img.addEventListener("load", () => {
+			if (img.width > 0) {
+				resolve(img);
+				return;
+			}
+			reject(new Error("Image not found"));
+		});
+		img.addEventListener("error", (err) => reject(err));
+		img.src = url;
+		img.setAttribute("crossorigin", "anonymous");
+	});
+
+type ExportImageFromSvgOptions = {
+	svgCanvas: SVGElement;
+	svgWidth: number;
+	svgHeight: number;
+	imageType: ExportImageType;
+	canvasColor: string;
+	backgroundImage: string;
+	exportWithBackgroundImage: boolean;
+	options?: ExportImageOptions;
+};
+
+export async function exportImageFromSvg({
+	svgCanvas,
+	svgWidth,
+	svgHeight,
+	imageType,
+	canvasColor,
+	backgroundImage,
+	exportWithBackgroundImage,
+	options,
+}: ExportImageFromSvgOptions): Promise<string> {
+	const exportWidth = options?.width ?? svgWidth;
+	const exportHeight = options?.height ?? svgHeight;
+	const canvasSketch = `data:image/svg+xml;base64,${btoa(svgCanvas.outerHTML)}`;
+	const loadImagePromises = [loadImage(canvasSketch)];
+
+	if (exportWithBackgroundImage && backgroundImage) {
+		try {
+			loadImagePromises.push(loadImage(backgroundImage));
+		} catch {
+			console.warn(
+				"exportWithBackgroundImage props is set without a valid background image URL. This option is ignored",
+			);
+		}
+	}
+
+	const images = await Promise.all(loadImagePromises);
+	const renderCanvas = document.createElement("canvas");
+	renderCanvas.setAttribute("width", exportWidth.toString());
+	renderCanvas.setAttribute("height", exportHeight.toString());
+	const context = renderCanvas.getContext("2d");
+
+	if (!context) {
+		throw Error("Canvas not rendered yet");
+	}
+
+	if (imageType === "jpeg" && !exportWithBackgroundImage) {
+		context.fillStyle = canvasColor;
+		context.fillRect(0, 0, exportWidth, exportHeight);
+	}
+
+	for (const image of images.reverse()) {
+		context.drawImage(image, 0, 0, exportWidth, exportHeight);
+	}
+
+	return renderCanvas.toDataURL(`image/${imageType}`);
+}

--- a/packages/react-sketch-canvas/src/Canvas/export/image.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/image.ts
@@ -2,6 +2,13 @@ import type { ExportImageOptions, ExportImageType } from "../../types";
 
 type LoadImageReturns = Promise<HTMLImageElement>;
 
+/**
+ * Load an image URL or data URL for canvas export.
+ *
+ * @remarks
+ * The image is configured for anonymous cross-origin loading so browser canvas
+ * security rules allow `toDataURL` when the remote server permits it.
+ */
 export const loadImage = (url: string): LoadImageReturns =>
 	new Promise((resolve, reject) => {
 		const img = new Image();
@@ -30,6 +37,14 @@ type ExportImageFromSvgParams = {
 
 type ExportImageFromSvgReturns = Promise<string>;
 
+/**
+ * Render a cloned SVG canvas into a raster image data URL.
+ *
+ * @remarks
+ * The SVG is serialized, loaded into an HTML image, then painted onto a
+ * temporary `<canvas>`. Background images are painted first so strokes remain
+ * visible above them.
+ */
 export async function exportImageFromSvg({
 	svgCanvas,
 	svgWidth,

--- a/packages/react-sketch-canvas/src/Canvas/export/image.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/image.ts
@@ -1,6 +1,8 @@
 import type { ExportImageOptions, ExportImageType } from "../../types";
 
-export const loadImage = (url: string): Promise<HTMLImageElement> =>
+type LoadImageReturns = Promise<HTMLImageElement>;
+
+export const loadImage = (url: string): LoadImageReturns =>
 	new Promise((resolve, reject) => {
 		const img = new Image();
 		img.addEventListener("load", () => {
@@ -15,7 +17,7 @@ export const loadImage = (url: string): Promise<HTMLImageElement> =>
 		img.setAttribute("crossorigin", "anonymous");
 	});
 
-type ExportImageFromSvgOptions = {
+type ExportImageFromSvgParams = {
 	svgCanvas: SVGElement;
 	svgWidth: number;
 	svgHeight: number;
@@ -26,6 +28,8 @@ type ExportImageFromSvgOptions = {
 	options?: ExportImageOptions;
 };
 
+type ExportImageFromSvgReturns = Promise<string>;
+
 export async function exportImageFromSvg({
 	svgCanvas,
 	svgWidth,
@@ -35,7 +39,7 @@ export async function exportImageFromSvg({
 	backgroundImage,
 	exportWithBackgroundImage,
 	options,
-}: ExportImageFromSvgOptions): Promise<string> {
+}: ExportImageFromSvgParams): ExportImageFromSvgReturns {
 	const exportWidth = options?.width ?? svgWidth;
 	const exportHeight = options?.height ?? svgHeight;
 	const canvasSketch = `data:image/svg+xml;base64,${btoa(svgCanvas.outerHTML)}`;
@@ -46,7 +50,7 @@ export async function exportImageFromSvg({
 			loadImagePromises.push(loadImage(backgroundImage));
 		} catch {
 			console.warn(
-				"exportWithBackgroundImage props is set without a valid background image URL. This option is ignored",
+				"React Sketch Canvas could not load the background image while exporting. Check that backgroundImage points to a reachable image and allows cross-origin access.",
 			);
 		}
 	}

--- a/packages/react-sketch-canvas/src/Canvas/export/svg.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/svg.ts
@@ -6,6 +6,14 @@ type PrepareSvgForExportParams = {
 
 type PrepareSvgForExportReturns = SVGElement;
 
+/**
+ * Prepare a cloned SVG element for export.
+ *
+ * @remarks
+ * When background image export is disabled, this removes the background image
+ * pattern reference and fills the canvas background with `canvasColor`. The
+ * input MUST be a cloned SVG because this function mutates the element.
+ */
 export function prepareSvgForExport(
 	svgCanvas: SVGElement,
 	{ id, canvasColor, exportWithBackgroundImage }: PrepareSvgForExportParams,

--- a/packages/react-sketch-canvas/src/Canvas/export/svg.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/svg.ts
@@ -1,0 +1,21 @@
+type PrepareSvgForExportOptions = {
+	id: string;
+	canvasColor: string;
+	exportWithBackgroundImage: boolean;
+};
+
+export function prepareSvgForExport(
+	svgCanvas: SVGElement,
+	{ id, canvasColor, exportWithBackgroundImage }: PrepareSvgForExportOptions,
+): SVGElement {
+	if (exportWithBackgroundImage) {
+		return svgCanvas;
+	}
+
+	svgCanvas.querySelector(`#${id}__background`)?.remove();
+	svgCanvas
+		.querySelector(`#${id}__canvas-background`)
+		?.setAttribute("fill", canvasColor);
+
+	return svgCanvas;
+}

--- a/packages/react-sketch-canvas/src/Canvas/export/svg.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/svg.ts
@@ -1,13 +1,15 @@
-type PrepareSvgForExportOptions = {
+type PrepareSvgForExportParams = {
 	id: string;
 	canvasColor: string;
 	exportWithBackgroundImage: boolean;
 };
 
+type PrepareSvgForExportReturns = SVGElement;
+
 export function prepareSvgForExport(
 	svgCanvas: SVGElement,
-	{ id, canvasColor, exportWithBackgroundImage }: PrepareSvgForExportOptions,
-): SVGElement {
+	{ id, canvasColor, exportWithBackgroundImage }: PrepareSvgForExportParams,
+): PrepareSvgForExportReturns {
 	if (exportWithBackgroundImage) {
 		return svgCanvas;
 	}

--- a/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasExportHandle.ts
+++ b/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasExportHandle.ts
@@ -5,13 +5,15 @@ import { exportImageFromSvg } from "../export/image";
 import { prepareSvgForExport } from "../export/svg";
 import type { CanvasRef } from "../types";
 
-type UseCanvasExportHandleOptions = {
+type UseCanvasExportHandleParams = {
 	canvasRef: React.RefObject<HTMLDivElement>;
 	id: string;
 	canvasColor: string;
 	backgroundImage: string;
 	exportWithBackgroundImage: boolean;
 };
+
+type UseCanvasExportHandleReturns = ReturnType<() => void>;
 
 export function useCanvasExportHandle(
 	ref: React.ForwardedRef<CanvasRef>,
@@ -21,8 +23,8 @@ export function useCanvasExportHandle(
 		canvasColor,
 		backgroundImage,
 		exportWithBackgroundImage,
-	}: UseCanvasExportHandleOptions,
-): void {
+	}: UseCanvasExportHandleParams,
+): UseCanvasExportHandleReturns {
 	React.useImperativeHandle(ref, () => ({
 		exportImage: async (
 			imageType: ExportImageType,

--- a/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasExportHandle.ts
+++ b/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasExportHandle.ts
@@ -3,18 +3,25 @@ import type { ExportImageOptions, ExportImageType } from "../../types";
 import { getCanvasWithViewBox } from "../export/dom";
 import { exportImageFromSvg } from "../export/image";
 import { prepareSvgForExport } from "../export/svg";
-import type { CanvasRef } from "../types";
+import type { CanvasProps, CanvasRef } from "../types";
 
-type UseCanvasExportHandleParams = {
-	canvasRef: React.RefObject<HTMLDivElement>;
-	id: string;
-	canvasColor: string;
-	backgroundImage: string;
-	exportWithBackgroundImage: boolean;
-};
+type UseCanvasExportHandleParams = Required<Pick<CanvasProps, "id">> &
+	Pick<
+		CanvasProps,
+		"canvasColor" | "backgroundImage" | "exportWithBackgroundImage"
+	> & {
+		canvasRef: React.RefObject<HTMLDivElement>;
+	};
 
 type UseCanvasExportHandleReturns = ReturnType<() => void>;
 
+/**
+ * Expose export methods from the low-level `Canvas` ref.
+ *
+ * @remarks
+ * The hook centralizes all DOM cloning and SVG/image export wiring so the
+ * component can stay focused on rendering and pointer handlers.
+ */
 export function useCanvasExportHandle(
 	ref: React.ForwardedRef<CanvasRef>,
 	{

--- a/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasExportHandle.ts
+++ b/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasExportHandle.ts
@@ -1,0 +1,65 @@
+import * as React from "react";
+import type { ExportImageOptions, ExportImageType } from "../../types";
+import { getCanvasWithViewBox } from "../export/dom";
+import { exportImageFromSvg } from "../export/image";
+import { prepareSvgForExport } from "../export/svg";
+import type { CanvasRef } from "../types";
+
+type UseCanvasExportHandleOptions = {
+	canvasRef: React.RefObject<HTMLDivElement>;
+	id: string;
+	canvasColor: string;
+	backgroundImage: string;
+	exportWithBackgroundImage: boolean;
+};
+
+export function useCanvasExportHandle(
+	ref: React.ForwardedRef<CanvasRef>,
+	{
+		canvasRef,
+		id,
+		canvasColor,
+		backgroundImage,
+		exportWithBackgroundImage,
+	}: UseCanvasExportHandleOptions,
+): void {
+	React.useImperativeHandle(ref, () => ({
+		exportImage: async (
+			imageType: ExportImageType,
+			options?: ExportImageOptions,
+		): Promise<string> => {
+			const canvas = canvasRef.current;
+
+			if (!canvas) {
+				throw Error("Canvas not rendered yet");
+			}
+
+			const { svgCanvas, width, height } = getCanvasWithViewBox(canvas);
+
+			return exportImageFromSvg({
+				svgCanvas,
+				svgWidth: width,
+				svgHeight: height,
+				imageType,
+				canvasColor,
+				backgroundImage,
+				exportWithBackgroundImage,
+				options,
+			});
+		},
+		exportSvg: async (): Promise<string> => {
+			const canvas = canvasRef.current;
+
+			if (!canvas) {
+				throw new Error("Canvas not loaded");
+			}
+
+			const { svgCanvas } = getCanvasWithViewBox(canvas);
+			return prepareSvgForExport(svgCanvas, {
+				id,
+				canvasColor,
+				exportWithBackgroundImage,
+			}).outerHTML;
+		},
+	}));
+}

--- a/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasPointerHandlers.ts
+++ b/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasPointerHandlers.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useCallback } from "react";
 import type { Point } from "../../types";
-import type { AllowOnlyPointerType } from "../types";
+import type { AllowOnlyPointerType, CanvasProps } from "../types";
 
 const ERASER_BUTTON_MASK = 32;
 
@@ -20,33 +20,57 @@ type ScrollLike = {
 	scrollY: number;
 };
 
-type UseCanvasPointerHandlersParams = {
+type CanvasSizeRef = React.MutableRefObject<{
+	width: number;
+	height: number;
+} | null>;
+
+type UseCanvasPointerHandlersParams = Pick<
+	CanvasProps,
+	| "isDrawing"
+	| "allowOnlyPointerType"
+	| "onPointerDown"
+	| "onPointerMove"
+	| "onPointerUp"
+> & {
 	canvasRef: React.RefObject<HTMLDivElement>;
-	canvasSizeRef: React.MutableRefObject<{
-		width: number;
-		height: number;
-	} | null>;
-	isDrawing: boolean;
-	allowOnlyPointerType: AllowOnlyPointerType;
-	onPointerDown: (point: Point, isEraser?: boolean) => void;
-	onPointerMove: (point: Point) => void;
-	onPointerUp: () => void;
+	canvasSizeRef: CanvasSizeRef;
 };
 
+type UseCanvasPointerHandlersReturns = {
+	handlePointerDown: (event: React.PointerEvent<HTMLDivElement>) => void;
+	handlePointerMove: (event: React.PointerEvent<HTMLDivElement>) => void;
+	handlePointerUp: (
+		event: React.PointerEvent<HTMLDivElement> | PointerEvent,
+	) => void;
+};
+
+/**
+ * Check whether a pointer event matches the configured input device filter.
+ */
 export const isAllowedPointerType = (
 	allowOnlyPointerType: AllowOnlyPointerType,
 	pointerType: string,
 ): boolean =>
 	allowOnlyPointerType === "all" || pointerType === allowOnlyPointerType;
 
+/**
+ * Ignore non-primary mouse buttons while allowing pen and touch pointer events.
+ */
 export const shouldHandlePointerButton = (
 	pointerType: string,
 	button: number,
 ): boolean => !(pointerType === "mouse" && button !== 0);
 
+/**
+ * Detect the barrel/eraser button used by pointer events from pen devices.
+ */
 export const isPenEraser = (pointerType: string, buttons: number): boolean =>
 	pointerType === "pen" && Math.floor(buttons / ERASER_BUTTON_MASK) % 2 === 1;
 
+/**
+ * Convert a page-level pointer coordinate into a canvas-relative point.
+ */
 export const getCanvasPoint = (
 	pointerEvent: PointerLike,
 	boundingArea: BoundsLike,
@@ -56,6 +80,14 @@ export const getCanvasPoint = (
 	y: pointerEvent.pageY - boundingArea.top - scroll.scrollY,
 });
 
+/**
+ * Build stable pointer handlers for the low-level canvas.
+ *
+ * @remarks
+ * The hook keeps DOM coordinate normalization, input filtering, and document
+ * level `pointerup` handling out of the `Canvas` component. It also records the
+ * latest canvas size so viewBox export can mirror the rendered dimensions.
+ */
 export function useCanvasPointerHandlers({
 	canvasRef,
 	canvasSizeRef,
@@ -64,7 +96,7 @@ export function useCanvasPointerHandlers({
 	onPointerDown,
 	onPointerMove,
 	onPointerUp,
-}: UseCanvasPointerHandlersParams) {
+}: UseCanvasPointerHandlersParams): UseCanvasPointerHandlersReturns {
 	const getCoordinates = useCallback(
 		(pointerEvent: React.PointerEvent<HTMLDivElement>): Point => {
 			const boundingArea = canvasRef.current?.getBoundingClientRect();

--- a/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasPointerHandlers.ts
+++ b/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasPointerHandlers.ts
@@ -1,0 +1,135 @@
+import * as React from "react";
+import { useCallback } from "react";
+import type { Point } from "../../types";
+import type { AllowOnlyPointerType } from "../types";
+
+const ERASER_BUTTON_MASK = 32;
+
+type PointerLike = {
+	pageX: number;
+	pageY: number;
+};
+
+type BoundsLike = {
+	left: number;
+	top: number;
+};
+
+type ScrollLike = {
+	scrollX: number;
+	scrollY: number;
+};
+
+type UseCanvasPointerHandlersParams = {
+	canvasRef: React.RefObject<HTMLDivElement>;
+	canvasSizeRef: React.MutableRefObject<{
+		width: number;
+		height: number;
+	} | null>;
+	isDrawing: boolean;
+	allowOnlyPointerType: AllowOnlyPointerType;
+	onPointerDown: (point: Point, isEraser?: boolean) => void;
+	onPointerMove: (point: Point) => void;
+	onPointerUp: () => void;
+};
+
+export const isAllowedPointerType = (
+	allowOnlyPointerType: AllowOnlyPointerType,
+	pointerType: string,
+): boolean =>
+	allowOnlyPointerType === "all" || pointerType === allowOnlyPointerType;
+
+export const shouldHandlePointerButton = (
+	pointerType: string,
+	button: number,
+): boolean => !(pointerType === "mouse" && button !== 0);
+
+export const isPenEraser = (pointerType: string, buttons: number): boolean =>
+	pointerType === "pen" && Math.floor(buttons / ERASER_BUTTON_MASK) % 2 === 1;
+
+export const getCanvasPoint = (
+	pointerEvent: PointerLike,
+	boundingArea: BoundsLike,
+	scroll: ScrollLike,
+): Point => ({
+	x: pointerEvent.pageX - boundingArea.left - scroll.scrollX,
+	y: pointerEvent.pageY - boundingArea.top - scroll.scrollY,
+});
+
+export function useCanvasPointerHandlers({
+	canvasRef,
+	canvasSizeRef,
+	isDrawing,
+	allowOnlyPointerType,
+	onPointerDown,
+	onPointerMove,
+	onPointerUp,
+}: UseCanvasPointerHandlersParams) {
+	const getCoordinates = useCallback(
+		(pointerEvent: React.PointerEvent<HTMLDivElement>): Point => {
+			const boundingArea = canvasRef.current?.getBoundingClientRect();
+			canvasSizeRef.current = boundingArea
+				? { width: boundingArea.width, height: boundingArea.height }
+				: null;
+
+			if (!boundingArea) {
+				return { x: 0, y: 0 };
+			}
+
+			return getCanvasPoint(pointerEvent, boundingArea, {
+				scrollX: window.scrollX ?? 0,
+				scrollY: window.scrollY ?? 0,
+			});
+		},
+		[canvasRef, canvasSizeRef],
+	);
+
+	const handlePointerDown = useCallback(
+		(event: React.PointerEvent<HTMLDivElement>): void => {
+			if (!isAllowedPointerType(allowOnlyPointerType, event.pointerType))
+				return;
+			if (!shouldHandlePointerButton(event.pointerType, event.button)) return;
+
+			onPointerDown(
+				getCoordinates(event),
+				isPenEraser(event.pointerType, event.buttons),
+			);
+		},
+		[allowOnlyPointerType, getCoordinates, onPointerDown],
+	);
+
+	const handlePointerMove = useCallback(
+		(event: React.PointerEvent<HTMLDivElement>): void => {
+			if (!isDrawing) return;
+			if (!isAllowedPointerType(allowOnlyPointerType, event.pointerType))
+				return;
+
+			onPointerMove(getCoordinates(event));
+		},
+		[allowOnlyPointerType, getCoordinates, isDrawing, onPointerMove],
+	);
+
+	const handlePointerUp = useCallback(
+		(event: React.PointerEvent<HTMLDivElement> | PointerEvent): void => {
+			if (!shouldHandlePointerButton(event.pointerType, event.button)) return;
+			if (!isAllowedPointerType(allowOnlyPointerType, event.pointerType))
+				return;
+
+			onPointerUp();
+		},
+		[allowOnlyPointerType, onPointerUp],
+	);
+
+	React.useEffect(() => {
+		document.addEventListener("pointerup", handlePointerUp);
+		return () => {
+			document.removeEventListener("pointerup", handlePointerUp);
+		};
+	}, [handlePointerUp]);
+
+	return {
+		handlePointerDown,
+		handlePointerMove,
+		handlePointerUp,
+	};
+}

--- a/packages/react-sketch-canvas/src/Canvas/index.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/index.tsx
@@ -1,35 +1,8 @@
 import * as React from "react";
-import type { ExportImageOptions, ExportImageType } from "../types";
+import { useCanvasExportHandle } from "./hooks/useCanvasExportHandle";
 import { useCanvasPointerHandlers } from "./hooks/useCanvasPointerHandlers";
 import { CanvasSvg } from "./svg/CanvasSvg";
 import type { CanvasProps, CanvasRef } from "./types";
-
-const loadImage = (url: string): Promise<HTMLImageElement> =>
-	new Promise((resolve, reject) => {
-		const img = new Image();
-		img.addEventListener("load", () => {
-			if (img.width > 0) {
-				resolve(img);
-			}
-			reject(new Error("Image not found"));
-		});
-		img.addEventListener("error", (err) => reject(err));
-		img.src = url;
-		img.setAttribute("crossorigin", "anonymous");
-	});
-
-function getCanvasWithViewBox(canvas: HTMLDivElement) {
-	const svgCanvas = canvas.firstChild?.cloneNode(true) as SVGElement;
-
-	const width = canvas.offsetWidth;
-	const height = canvas.offsetHeight;
-
-	svgCanvas.setAttribute("viewBox", `0 0 ${width} ${height}`);
-
-	svgCanvas.setAttribute("width", width.toString());
-	svgCanvas.setAttribute("height", height.toString());
-	return { svgCanvas, width, height };
-}
 
 /**
  * Canvas component
@@ -71,6 +44,14 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 		null,
 	);
 
+	useCanvasExportHandle(ref, {
+		canvasRef,
+		id,
+		canvasColor,
+		backgroundImage,
+		exportWithBackgroundImage,
+	});
+
 	const { handlePointerDown, handlePointerMove, handlePointerUp } =
 		useCanvasPointerHandlers({
 			canvasRef,
@@ -81,101 +62,6 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 			onPointerMove,
 			onPointerUp,
 		});
-
-	React.useImperativeHandle(ref, () => ({
-		exportImage: (
-			imageType: ExportImageType,
-			options?: ExportImageOptions,
-		): Promise<string> =>
-			new Promise<string>((resolve, reject) => {
-				try {
-					const canvas = canvasRef.current;
-
-					if (!canvas) {
-						throw Error("Canvas not rendered yet");
-					}
-
-					const {
-						svgCanvas,
-						width: svgWidth,
-						height: svgHeight,
-					} = getCanvasWithViewBox(canvas);
-					const exportWidth = options?.width ?? svgWidth;
-					const exportHeight = options?.height ?? svgHeight;
-
-					const canvasSketch = `data:image/svg+xml;base64,${btoa(
-						svgCanvas.outerHTML,
-					)}`;
-
-					const loadImagePromises = [loadImage(canvasSketch)];
-
-					if (exportWithBackgroundImage && backgroundImage) {
-						try {
-							const img = loadImage(backgroundImage);
-							loadImagePromises.push(img);
-						} catch (error) {
-							console.warn(
-								"exportWithBackgroundImage props is set without a valid background image URL. This option is ignored",
-							);
-						}
-					}
-
-					Promise.all(loadImagePromises)
-						.then((images) => {
-							const renderCanvas = document.createElement("canvas");
-							renderCanvas.setAttribute("width", exportWidth.toString());
-							renderCanvas.setAttribute("height", exportHeight.toString());
-							const context = renderCanvas.getContext("2d");
-
-							if (!context) {
-								throw Error("Canvas not rendered yet");
-							}
-
-							if (imageType === "jpeg" && !exportWithBackgroundImage) {
-								context.fillStyle = canvasColor;
-								context.fillRect(0, 0, exportWidth, exportHeight);
-							}
-
-							for (const image of images.reverse()) {
-								context.drawImage(image, 0, 0, exportWidth, exportHeight);
-							}
-
-							resolve(renderCanvas.toDataURL(`image/${imageType}`));
-						})
-						.catch((e) => {
-							reject(e);
-						});
-				} catch (e) {
-					reject(e);
-				}
-			}),
-		exportSvg: (): Promise<string> =>
-			new Promise<string>((resolve, reject) => {
-				try {
-					const canvas = canvasRef.current ?? null;
-
-					if (canvas !== null) {
-						const { svgCanvas } = getCanvasWithViewBox(canvas);
-
-						if (exportWithBackgroundImage) {
-							resolve(svgCanvas.outerHTML);
-							return;
-						}
-
-						svgCanvas.querySelector(`#${id}__background`)?.remove();
-						svgCanvas
-							.querySelector(`#${id}__canvas-background`)
-							?.setAttribute("fill", canvasColor);
-
-						resolve(svgCanvas.outerHTML);
-					}
-
-					reject(new Error("Canvas not loaded"));
-				} catch (e) {
-					reject(e);
-				}
-			}),
-	}));
 
 	const viewBox =
 		withViewBox && canvasSizeRef.current !== null

--- a/packages/react-sketch-canvas/src/Canvas/index.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/index.tsx
@@ -1,12 +1,7 @@
 import * as React from "react";
 import { useCallback } from "react";
-import Paths, { SvgPath } from "../Paths";
-import type {
-	CanvasPath,
-	ExportImageOptions,
-	ExportImageType,
-	Point,
-} from "../types";
+import type { ExportImageOptions, ExportImageType, Point } from "../types";
+import { CanvasSvg } from "./svg/CanvasSvg";
 import type { CanvasProps, CanvasRef } from "./types";
 
 const ERASER_BUTTON_MASK = 32;
@@ -271,32 +266,6 @@ release drawing even when point goes out of canvas */
 		};
 	}, [handlePointerUp]);
 
-	const eraserPaths = React.useMemo(
-		() => paths.filter((path) => !path.drawMode),
-		[paths],
-	);
-
-	const pathGroups = React.useMemo(() => {
-		let currentGroup = 0;
-
-		return paths.reduce<CanvasPath[][]>(
-			(arrayGroup, path) => {
-				if (!path.drawMode) {
-					currentGroup += 1;
-					return arrayGroup;
-				}
-
-				if (arrayGroup[currentGroup] === undefined) {
-					arrayGroup[currentGroup] = [];
-				}
-
-				arrayGroup[currentGroup].push(path);
-				return arrayGroup;
-			},
-			[[]],
-		);
-	}, [paths]);
-
 	const viewBox =
 		withViewBox && canvasSizeRef.current !== null
 			? `0 0 ${canvasSizeRef.current.width} ${canvasSizeRef.current.height}`
@@ -317,108 +286,15 @@ release drawing even when point goes out of canvas */
 			onPointerMove={readOnly ? undefined : handlePointerMove}
 			onPointerUp={readOnly ? undefined : handlePointerUp}
 		>
-			<svg
-				version="1.1"
-				baseProfile="full"
-				xmlns="http://www.w3.org/2000/svg"
-				xmlnsXlink="http://www.w3.org/1999/xlink"
-				aria-hidden="true"
-				style={{
-					width: "100%",
-					height: "100%",
-					...svgStyle,
-				}}
+			<CanvasSvg
 				id={id}
+				paths={paths}
+				canvasColor={canvasColor}
+				backgroundImage={backgroundImage}
+				preserveBackgroundImageAspectRatio={preserveBackgroundImageAspectRatio}
+				svgStyle={svgStyle}
 				viewBox={viewBox}
-			>
-				<g id={`${id}__eraser-stroke-group`} display="none">
-					<rect
-						id={`${id}__mask-background`}
-						x="0"
-						y="0"
-						width="100%"
-						height="100%"
-						fill="white"
-					/>
-					{eraserPaths.map((eraserPath, i) => (
-						<SvgPath
-							// biome-ignore lint/suspicious/noArrayIndexKey: eraser masks are generated from ordered strokes with no domain id.
-							key={`${id}__eraser-${i}`}
-							id={`${id}__eraser-${i}`}
-							paths={eraserPath.paths}
-							strokeColor="#000000"
-							strokeWidth={eraserPath.strokeWidth}
-						/>
-					))}
-				</g>
-				<defs>
-					{backgroundImage && (
-						<pattern
-							id={`${id}__background`}
-							x="0"
-							y="0"
-							width="100%"
-							height="100%"
-							patternUnits="userSpaceOnUse"
-						>
-							<image
-								x="0"
-								y="0"
-								width="100%"
-								height="100%"
-								xlinkHref={backgroundImage}
-								preserveAspectRatio={preserveBackgroundImageAspectRatio}
-							/>
-						</pattern>
-					)}
-
-					{eraserPaths.map((_, i) => (
-						<mask
-							id={`${id}__eraser-mask-${i}`}
-							// biome-ignore lint/suspicious/noArrayIndexKey: mask order is tied to ordered eraser strokes.
-							key={`${id}__eraser-mask-${i}`}
-							maskUnits="userSpaceOnUse"
-						>
-							<use
-								href={`#${id}__mask-background`}
-								xlinkHref={`#${id}__mask-background`}
-							/>
-							{Array.from(
-								{ length: eraserPaths.length - i },
-								(_i, j) => j + i,
-							).map((k) => (
-								<use
-									key={k.toString()}
-									href={`#${id}__eraser-${k.toString()}`}
-									xlinkHref={`#${id}__eraser-${k.toString()}`}
-								/>
-							))}
-						</mask>
-					))}
-				</defs>
-				<g id={`${id}__canvas-background-group`}>
-					<rect
-						id={`${id}__canvas-background`}
-						x="0"
-						y="0"
-						width="100%"
-						height="100%"
-						fill={backgroundImage ? `url(#${id}__background)` : canvasColor}
-					/>
-				</g>
-				{pathGroups.map((pathGroup, i) => (
-					<g
-						id={`${id}__stroke-group-${i}`}
-						// biome-ignore lint/suspicious/noArrayIndexKey: stroke groups are ordered drawing segments with no domain id.
-						key={`${id}__stroke-group-${i}`}
-						{...(eraserPaths[i]
-							? { mask: `url(#${id}__eraser-mask-${i})` }
-							: {})}
-					>
-						<Paths id={`${id}__stroke-group-${i}__paths`} paths={pathGroup} />
-					</g>
-				))}
-			</svg>
+			/>
 		</div>
 	);
 });

--- a/packages/react-sketch-canvas/src/Canvas/index.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/index.tsx
@@ -1,10 +1,8 @@
 import * as React from "react";
-import { useCallback } from "react";
-import type { ExportImageOptions, ExportImageType, Point } from "../types";
+import type { ExportImageOptions, ExportImageType } from "../types";
+import { useCanvasPointerHandlers } from "./hooks/useCanvasPointerHandlers";
 import { CanvasSvg } from "./svg/CanvasSvg";
 import type { CanvasProps, CanvasRef } from "./types";
-
-const ERASER_BUTTON_MASK = 32;
 
 const loadImage = (url: string): Promise<HTMLImageElement> =>
 	new Promise((resolve, reject) => {
@@ -73,94 +71,16 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 		null,
 	);
 
-	// Converts mouse coordinates to relative coordinate based on the absolute position of svg
-	const getCoordinates = useCallback(
-		(pointerEvent: React.PointerEvent<HTMLDivElement>): Point => {
-			const boundingArea = canvasRef.current?.getBoundingClientRect();
-			canvasSizeRef.current = boundingArea
-				? {
-						width: boundingArea.width,
-						height: boundingArea.height,
-					}
-				: null;
-
-			const scrollLeft = window.scrollX ?? 0;
-			const scrollTop = window.scrollY ?? 0;
-
-			if (!boundingArea) {
-				return { x: 0, y: 0 };
-			}
-
-			return {
-				x: pointerEvent.pageX - boundingArea.left - scrollLeft,
-				y: pointerEvent.pageY - boundingArea.top - scrollTop,
-			};
-		},
-		[],
-	);
-
-	/* Mouse Handlers - Mouse down, move and up */
-
-	const handlePointerDown = useCallback(
-		(event: React.PointerEvent<HTMLDivElement>): void => {
-			// Allow only chosen pointer type
-
-			if (
-				allowOnlyPointerType !== "all" &&
-				event.pointerType !== allowOnlyPointerType
-			) {
-				return;
-			}
-
-			if (event.pointerType === "mouse" && event.button !== 0) return;
-
-			const isEraser =
-				event.pointerType === "pen" &&
-				Math.floor(event.buttons / ERASER_BUTTON_MASK) % 2 === 1;
-			const point = getCoordinates(event);
-
-			onPointerDown(point, isEraser);
-		},
-		[allowOnlyPointerType, getCoordinates, onPointerDown],
-	);
-
-	const handlePointerMove = useCallback(
-		(event: React.PointerEvent<HTMLDivElement>): void => {
-			if (!isDrawing) return;
-
-			// Allow only chosen pointer type
-			if (
-				allowOnlyPointerType !== "all" &&
-				event.pointerType !== allowOnlyPointerType
-			) {
-				return;
-			}
-
-			const point = getCoordinates(event);
-
-			onPointerMove(point);
-		},
-		[allowOnlyPointerType, getCoordinates, isDrawing, onPointerMove],
-	);
-
-	const handlePointerUp = useCallback(
-		(event: React.PointerEvent<HTMLDivElement> | PointerEvent): void => {
-			if (event.pointerType === "mouse" && event.button !== 0) return;
-
-			// Allow only chosen pointer type
-			if (
-				allowOnlyPointerType !== "all" &&
-				event.pointerType !== allowOnlyPointerType
-			) {
-				return;
-			}
-
-			onPointerUp();
-		},
-		[allowOnlyPointerType, onPointerUp],
-	);
-
-	/* Mouse Handlers ends */
+	const { handlePointerDown, handlePointerMove, handlePointerUp } =
+		useCanvasPointerHandlers({
+			canvasRef,
+			canvasSizeRef,
+			isDrawing,
+			allowOnlyPointerType,
+			onPointerDown,
+			onPointerMove,
+			onPointerUp,
+		});
 
 	React.useImperativeHandle(ref, () => ({
 		exportImage: (
@@ -256,15 +176,6 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 				}
 			}),
 	}));
-
-	/* Add event listener to Mouse up and Touch up to
-release drawing even when point goes out of canvas */
-	React.useEffect(() => {
-		document.addEventListener("pointerup", handlePointerUp);
-		return () => {
-			document.removeEventListener("pointerup", handlePointerUp);
-		};
-	}, [handlePointerUp]);
 
 	const viewBox =
 		withViewBox && canvasSizeRef.current !== null

--- a/packages/react-sketch-canvas/src/Canvas/index.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/index.tsx
@@ -5,95 +5,118 @@ import { CanvasSvg } from "./svg/CanvasSvg";
 import type { CanvasProps, CanvasRef } from "./types";
 
 /**
- * Canvas component
+ * Type of the low-level SVG canvas component.
  *
- * This is a low-level component that is used to draw on the canvas.
- * This component is used by the ReactSketchCanvas component with some additional features.
- *
- * @param props - The props for the Canvas component
- * @param ref - The ref for the Canvas component
- * @returns The Canvas component
+ * @remarks
+ * Keeping this explicit preserves the public prop and ref contract in generated
+ * declaration files.
  */
-export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
-	const {
-		paths,
-		isDrawing,
-		onPointerDown,
-		onPointerMove,
-		onPointerUp,
-		id = "react-sketch-canvas",
-		width = "100%",
-		height = "100%",
-		className = "react-sketch-canvas",
-		canvasColor = "white",
-		backgroundImage = "",
-		exportWithBackgroundImage = false,
-		preserveBackgroundImageAspectRatio = "none",
-		allowOnlyPointerType = "all",
-		style = {
-			border: "0.0625rem solid #9c9c9c",
-			borderRadius: "0.25rem",
-		},
-		svgStyle = {},
-		withViewBox = false,
-		readOnly = false,
-	} = props;
+type CanvasComponent = React.ForwardRefExoticComponent<
+	CanvasProps & React.RefAttributes<CanvasRef>
+>;
 
-	const canvasRef = React.useRef<HTMLDivElement>(null);
-	const canvasSizeRef = React.useRef<{ width: number; height: number } | null>(
-		null,
-	);
-
-	useCanvasExportHandle(ref, {
-		canvasRef,
-		id,
-		canvasColor,
-		backgroundImage,
-		exportWithBackgroundImage,
-	});
-
-	const { handlePointerDown, handlePointerMove, handlePointerUp } =
-		useCanvasPointerHandlers({
-			canvasRef,
-			canvasSizeRef,
+/**
+ * Low-level SVG drawing canvas.
+ *
+ * @remarks
+ * `Canvas` renders the SVG surface, handles pointer normalization, and exposes
+ * export methods through its forwarded ref. Most consumers should use
+ * `ReactSketchCanvas` instead, which manages drawing state and undo/redo.
+ *
+ * Use `Canvas` directly when you need full control over path state, custom
+ * history behavior, or integration with an external drawing state machine.
+ *
+ * @param props - Rendering, pointer, and export options for the canvas.
+ * @param ref - Ref exposing {@link CanvasRef} export methods.
+ * @returns The low-level canvas element.
+ *
+ * @public
+ */
+export const Canvas: CanvasComponent = React.forwardRef<CanvasRef, CanvasProps>(
+	(props, ref) => {
+		const {
+			paths,
 			isDrawing,
-			allowOnlyPointerType,
 			onPointerDown,
 			onPointerMove,
 			onPointerUp,
+			id = "react-sketch-canvas",
+			width = "100%",
+			height = "100%",
+			className = "react-sketch-canvas",
+			canvasColor = "white",
+			backgroundImage = "",
+			exportWithBackgroundImage = false,
+			preserveBackgroundImageAspectRatio = "none",
+			allowOnlyPointerType = "all",
+			style = {
+				border: "0.0625rem solid #9c9c9c",
+				borderRadius: "0.25rem",
+			},
+			svgStyle = {},
+			withViewBox = false,
+			readOnly = false,
+		} = props;
+
+		const canvasRef = React.useRef<HTMLDivElement>(null);
+		const canvasSizeRef = React.useRef<{
+			width: number;
+			height: number;
+		} | null>(null);
+
+		useCanvasExportHandle(ref, {
+			canvasRef,
+			id,
+			canvasColor,
+			backgroundImage,
+			exportWithBackgroundImage,
 		});
 
-	const viewBox =
-		withViewBox && canvasSizeRef.current !== null
-			? `0 0 ${canvasSizeRef.current.width} ${canvasSizeRef.current.height}`
-			: undefined;
+		const { handlePointerDown, handlePointerMove, handlePointerUp } =
+			useCanvasPointerHandlers({
+				canvasRef,
+				canvasSizeRef,
+				isDrawing,
+				allowOnlyPointerType,
+				onPointerDown,
+				onPointerMove,
+				onPointerUp,
+			});
 
-	return (
-		<div
-			role="presentation"
-			ref={canvasRef}
-			className={className}
-			style={{
-				touchAction: "none",
-				width,
-				height,
-				...style,
-			}}
-			onPointerDown={readOnly ? undefined : handlePointerDown}
-			onPointerMove={readOnly ? undefined : handlePointerMove}
-			onPointerUp={readOnly ? undefined : handlePointerUp}
-		>
-			<CanvasSvg
-				id={id}
-				paths={paths}
-				canvasColor={canvasColor}
-				backgroundImage={backgroundImage}
-				preserveBackgroundImageAspectRatio={preserveBackgroundImageAspectRatio}
-				svgStyle={svgStyle}
-				viewBox={viewBox}
-			/>
-		</div>
-	);
-});
+		const viewBox =
+			withViewBox && canvasSizeRef.current !== null
+				? `0 0 ${canvasSizeRef.current.width} ${canvasSizeRef.current.height}`
+				: undefined;
+
+		return (
+			<div
+				role="presentation"
+				ref={canvasRef}
+				className={className}
+				style={{
+					touchAction: "none",
+					width,
+					height,
+					...style,
+				}}
+				onPointerDown={readOnly ? undefined : handlePointerDown}
+				onPointerMove={readOnly ? undefined : handlePointerMove}
+				onPointerUp={readOnly ? undefined : handlePointerUp}
+			>
+				<CanvasSvg
+					id={id}
+					paths={paths}
+					canvasColor={canvasColor}
+					backgroundImage={backgroundImage}
+					preserveBackgroundImageAspectRatio={
+						preserveBackgroundImageAspectRatio
+					}
+					svgStyle={svgStyle}
+					viewBox={viewBox}
+				/>
+			</div>
+		);
+	},
+);
 
 Canvas.displayName = "@react-sketch-canvas/Canvas";

--- a/packages/react-sketch-canvas/src/Canvas/svg/Background.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/Background.tsx
@@ -1,0 +1,61 @@
+import type * as React from "react";
+
+type BackgroundProps = {
+	id: string;
+	backgroundImage: string;
+	canvasColor: string;
+	preserveBackgroundImageAspectRatio?: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"];
+};
+
+export function BackgroundPattern({
+	id,
+	backgroundImage,
+	preserveBackgroundImageAspectRatio,
+}: Pick<
+	BackgroundProps,
+	"id" | "backgroundImage" | "preserveBackgroundImageAspectRatio"
+>): JSX.Element | null {
+	if (!backgroundImage) return null;
+
+	return (
+		<pattern
+			id={`${id}__background`}
+			x="0"
+			y="0"
+			width="100%"
+			height="100%"
+			patternUnits="userSpaceOnUse"
+		>
+			<image
+				x="0"
+				y="0"
+				width="100%"
+				height="100%"
+				xlinkHref={backgroundImage}
+				preserveAspectRatio={preserveBackgroundImageAspectRatio}
+			/>
+		</pattern>
+	);
+}
+
+export function BackgroundRect({
+	id,
+	backgroundImage,
+	canvasColor,
+}: Pick<
+	BackgroundProps,
+	"id" | "backgroundImage" | "canvasColor"
+>): JSX.Element {
+	return (
+		<g id={`${id}__canvas-background-group`}>
+			<rect
+				id={`${id}__canvas-background`}
+				x="0"
+				y="0"
+				width="100%"
+				height="100%"
+				fill={backgroundImage ? `url(#${id}__background)` : canvasColor}
+			/>
+		</g>
+	);
+}

--- a/packages/react-sketch-canvas/src/Canvas/svg/Background.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/Background.tsx
@@ -1,12 +1,18 @@
-import type * as React from "react";
+import type { CanvasProps } from "../types";
 
-type BackgroundProps = {
-	id: string;
-	backgroundImage: string;
-	canvasColor: string;
-	preserveBackgroundImageAspectRatio?: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"];
-};
+type BackgroundProps = Required<Pick<CanvasProps, "id">> &
+	Pick<
+		CanvasProps,
+		"backgroundImage" | "canvasColor" | "preserveBackgroundImageAspectRatio"
+	>;
 
+/**
+ * Defines the SVG pattern used to paint a configured background image.
+ *
+ * @remarks
+ * The pattern is rendered only when a background image exists. The visible
+ * rectangle decides whether to reference this pattern or use `canvasColor`.
+ */
 export function BackgroundPattern({
 	id,
 	backgroundImage,
@@ -38,6 +44,13 @@ export function BackgroundPattern({
 	);
 }
 
+/**
+ * Renders the background rectangle that sits behind all sketch strokes.
+ *
+ * @remarks
+ * The rectangle id is stable because export code uses it to remove or recolor
+ * the background when producing SVG output.
+ */
 export function BackgroundRect({
 	id,
 	backgroundImage,

--- a/packages/react-sketch-canvas/src/Canvas/svg/CanvasSvg.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/CanvasSvg.tsx
@@ -1,0 +1,64 @@
+import type * as React from "react";
+import type { CanvasPath } from "../../types";
+import { BackgroundPattern, BackgroundRect } from "./Background";
+import { EraserMaskDefs, HiddenEraserStrokes } from "./EraserMasks";
+import { StrokeGroups } from "./StrokeGroups";
+import { getEraserPaths, getPathGroups } from "./grouping";
+
+type CanvasSvgProps = {
+	id: string;
+	paths: CanvasPath[];
+	canvasColor: string;
+	backgroundImage: string;
+	preserveBackgroundImageAspectRatio?: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"];
+	svgStyle: React.CSSProperties;
+	viewBox?: string;
+};
+
+export function CanvasSvg({
+	id,
+	paths,
+	canvasColor,
+	backgroundImage,
+	preserveBackgroundImageAspectRatio,
+	svgStyle,
+	viewBox,
+}: CanvasSvgProps): JSX.Element {
+	const eraserPaths = getEraserPaths(paths);
+	const pathGroups = getPathGroups(paths);
+
+	return (
+		<svg
+			version="1.1"
+			baseProfile="full"
+			xmlns="http://www.w3.org/2000/svg"
+			xmlnsXlink="http://www.w3.org/1999/xlink"
+			aria-hidden="true"
+			style={{
+				width: "100%",
+				height: "100%",
+				...svgStyle,
+			}}
+			id={id}
+			viewBox={viewBox}
+		>
+			<HiddenEraserStrokes id={id} eraserPaths={eraserPaths} />
+			<defs>
+				<BackgroundPattern
+					id={id}
+					backgroundImage={backgroundImage}
+					preserveBackgroundImageAspectRatio={
+						preserveBackgroundImageAspectRatio
+					}
+				/>
+				<EraserMaskDefs id={id} eraserPaths={eraserPaths} />
+			</defs>
+			<BackgroundRect
+				id={id}
+				backgroundImage={backgroundImage}
+				canvasColor={canvasColor}
+			/>
+			<StrokeGroups id={id} pathGroups={pathGroups} eraserPaths={eraserPaths} />
+		</svg>
+	);
+}

--- a/packages/react-sketch-canvas/src/Canvas/svg/CanvasSvg.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/CanvasSvg.tsx
@@ -1,20 +1,30 @@
-import type * as React from "react";
 import type { CanvasPath } from "../../types";
+import type { CanvasProps } from "../types";
 import { BackgroundPattern, BackgroundRect } from "./Background";
 import { EraserMaskDefs, HiddenEraserStrokes } from "./EraserMasks";
 import { StrokeGroups } from "./StrokeGroups";
 import { getEraserPaths, getPathGroups } from "./grouping";
 
-type CanvasSvgProps = {
-	id: string;
-	paths: CanvasPath[];
-	canvasColor: string;
-	backgroundImage: string;
-	preserveBackgroundImageAspectRatio?: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"];
-	svgStyle: React.CSSProperties;
-	viewBox?: string;
-};
+type CanvasSvgProps = Required<Pick<CanvasProps, "id">> &
+	Pick<
+		CanvasProps,
+		| "paths"
+		| "canvasColor"
+		| "backgroundImage"
+		| "preserveBackgroundImageAspectRatio"
+		| "svgStyle"
+	> & {
+		viewBox?: string;
+	};
 
+/**
+ * Renders the complete SVG tree for the canvas.
+ *
+ * @remarks
+ * This component keeps SVG construction separate from pointer and export logic.
+ * It renders hidden eraser strokes, mask definitions, background markup, and
+ * visible stroke groups in the order required for erasing to work.
+ */
 export function CanvasSvg({
 	id,
 	paths,

--- a/packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx
@@ -1,11 +1,19 @@
 import { SvgPath } from "../../Paths";
 import type { CanvasPath } from "../../types";
+import type { CanvasProps } from "../types";
 
-type EraserMasksProps = {
-	id: string;
+type EraserMasksProps = Required<Pick<CanvasProps, "id">> & {
 	eraserPaths: CanvasPath[];
 };
 
+/**
+ * Renders hidden eraser strokes that SVG masks can reference by id.
+ *
+ * @remarks
+ * The strokes are not visible in the final canvas. They provide reusable mask
+ * shapes so each drawing group can be clipped by the erasers that occur after
+ * it in path order.
+ */
 export function HiddenEraserStrokes({
 	id,
 	eraserPaths,
@@ -34,6 +42,14 @@ export function HiddenEraserStrokes({
 	);
 }
 
+/**
+ * Defines one SVG mask for each eraser stroke.
+ *
+ * @remarks
+ * Each mask includes the current eraser and all later erasers. This preserves
+ * path ordering: a drawing group is erased only by eraser strokes that were
+ * created after that drawing group.
+ */
 export function EraserMaskDefs({
 	id,
 	eraserPaths,

--- a/packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx
@@ -1,0 +1,67 @@
+import { SvgPath } from "../../Paths";
+import type { CanvasPath } from "../../types";
+
+type EraserMasksProps = {
+	id: string;
+	eraserPaths: CanvasPath[];
+};
+
+export function HiddenEraserStrokes({
+	id,
+	eraserPaths,
+}: EraserMasksProps): JSX.Element {
+	return (
+		<g id={`${id}__eraser-stroke-group`} display="none">
+			<rect
+				id={`${id}__mask-background`}
+				x="0"
+				y="0"
+				width="100%"
+				height="100%"
+				fill="white"
+			/>
+			{eraserPaths.map((eraserPath, i) => (
+				<SvgPath
+					// biome-ignore lint/suspicious/noArrayIndexKey: eraser masks are generated from ordered strokes with no domain id.
+					key={`${id}__eraser-${i}`}
+					id={`${id}__eraser-${i}`}
+					paths={eraserPath.paths}
+					strokeColor="#000000"
+					strokeWidth={eraserPath.strokeWidth}
+				/>
+			))}
+		</g>
+	);
+}
+
+export function EraserMaskDefs({
+	id,
+	eraserPaths,
+}: EraserMasksProps): JSX.Element {
+	return (
+		<>
+			{eraserPaths.map((_, i) => (
+				<mask
+					id={`${id}__eraser-mask-${i}`}
+					// biome-ignore lint/suspicious/noArrayIndexKey: mask order is tied to ordered eraser strokes.
+					key={`${id}__eraser-mask-${i}`}
+					maskUnits="userSpaceOnUse"
+				>
+					<use
+						href={`#${id}__mask-background`}
+						xlinkHref={`#${id}__mask-background`}
+					/>
+					{Array.from({ length: eraserPaths.length - i }, (_i, j) => j + i).map(
+						(k) => (
+							<use
+								key={k.toString()}
+								href={`#${id}__eraser-${k.toString()}`}
+								xlinkHref={`#${id}__eraser-${k.toString()}`}
+							/>
+						),
+					)}
+				</mask>
+			))}
+		</>
+	);
+}

--- a/packages/react-sketch-canvas/src/Canvas/svg/StrokeGroups.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/StrokeGroups.tsx
@@ -1,12 +1,20 @@
 import Paths from "../../Paths";
 import type { CanvasPath } from "../../types";
+import type { CanvasProps } from "../types";
 
-type StrokeGroupsProps = {
-	id: string;
+type StrokeGroupsProps = Required<Pick<CanvasProps, "id">> & {
 	pathGroups: CanvasPath[][];
 	eraserPaths: CanvasPath[];
 };
 
+/**
+ * Renders visible drawing strokes grouped between eraser strokes.
+ *
+ * @remarks
+ * The group index lines up with eraser mask indexes from `EraserMaskDefs`.
+ * Keeping these groups separate is what lets SVG masks emulate canvas-style
+ * erasing without mutating existing path data.
+ */
 export function StrokeGroups({
 	id,
 	pathGroups,
@@ -16,9 +24,9 @@ export function StrokeGroups({
 		<>
 			{pathGroups.map((pathGroup, i) => (
 				<g
-					id={`${id}__stroke-group-${i}`}
 					// biome-ignore lint/suspicious/noArrayIndexKey: stroke groups are ordered drawing segments with no domain id.
 					key={`${id}__stroke-group-${i}`}
+					id={`${id}__stroke-group-${i}`}
 					{...(eraserPaths[i] ? { mask: `url(#${id}__eraser-mask-${i})` } : {})}
 				>
 					<Paths id={`${id}__stroke-group-${i}__paths`} paths={pathGroup} />

--- a/packages/react-sketch-canvas/src/Canvas/svg/StrokeGroups.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/StrokeGroups.tsx
@@ -1,0 +1,29 @@
+import Paths from "../../Paths";
+import type { CanvasPath } from "../../types";
+
+type StrokeGroupsProps = {
+	id: string;
+	pathGroups: CanvasPath[][];
+	eraserPaths: CanvasPath[];
+};
+
+export function StrokeGroups({
+	id,
+	pathGroups,
+	eraserPaths,
+}: StrokeGroupsProps): JSX.Element {
+	return (
+		<>
+			{pathGroups.map((pathGroup, i) => (
+				<g
+					id={`${id}__stroke-group-${i}`}
+					// biome-ignore lint/suspicious/noArrayIndexKey: stroke groups are ordered drawing segments with no domain id.
+					key={`${id}__stroke-group-${i}`}
+					{...(eraserPaths[i] ? { mask: `url(#${id}__eraser-mask-${i})` } : {})}
+				>
+					<Paths id={`${id}__stroke-group-${i}__paths`} paths={pathGroup} />
+				</g>
+			))}
+		</>
+	);
+}

--- a/packages/react-sketch-canvas/src/Canvas/svg/grouping.ts
+++ b/packages/react-sketch-canvas/src/Canvas/svg/grouping.ts
@@ -1,8 +1,23 @@
 import type { CanvasPath } from "../../types";
 
+/**
+ * Return only eraser strokes from an ordered path list.
+ *
+ * @remarks
+ * Eraser strokes are represented as normal paths with `drawMode` set to
+ * `false`. Rendering code uses this list to build SVG masks.
+ */
 export const getEraserPaths = (paths: CanvasPath[]): CanvasPath[] =>
 	paths.filter((path) => !path.drawMode);
 
+/**
+ * Split drawing strokes into groups separated by eraser strokes.
+ *
+ * @remarks
+ * Each group is rendered with the eraser mask that corresponds to its position
+ * in the full path sequence. Empty groups are retained so mask indexes stay in
+ * sync with eraser indexes.
+ */
 export const getPathGroups = (paths: CanvasPath[]): CanvasPath[][] => {
 	let currentGroup = 0;
 

--- a/packages/react-sketch-canvas/src/Canvas/svg/grouping.ts
+++ b/packages/react-sketch-canvas/src/Canvas/svg/grouping.ts
@@ -1,0 +1,25 @@
+import type { CanvasPath } from "../../types";
+
+export const getEraserPaths = (paths: CanvasPath[]): CanvasPath[] =>
+	paths.filter((path) => !path.drawMode);
+
+export const getPathGroups = (paths: CanvasPath[]): CanvasPath[][] => {
+	let currentGroup = 0;
+
+	return paths.reduce<CanvasPath[][]>(
+		(arrayGroup, path) => {
+			if (!path.drawMode) {
+				currentGroup += 1;
+				return arrayGroup;
+			}
+
+			if (arrayGroup[currentGroup] === undefined) {
+				arrayGroup[currentGroup] = [];
+			}
+
+			arrayGroup[currentGroup].push(path);
+			return arrayGroup;
+		},
+		[[]],
+	);
+};

--- a/packages/react-sketch-canvas/src/Canvas/types.ts
+++ b/packages/react-sketch-canvas/src/Canvas/types.ts
@@ -7,137 +7,224 @@ import type {
 } from "../types";
 
 /**
- * The pointer type to allow drawing with.
+ * Pointer device class accepted by the drawing surface.
  *
+ * @remarks
+ * Use `"all"` to accept mouse, pen, and touch input. Use a specific pointer
+ * type when the canvas should ignore other input devices, for example a
+ * pen-only signing flow.
+ *
+ * @public
  */
 export type AllowOnlyPointerType = "all" | "pen" | "mouse" | "touch";
 
 /**
- * Canvas component props.
+ * Props for the low-level {@link Canvas} component.
+ *
+ * @remarks
+ * These props are primarily useful for composing a custom state manager around
+ * the low-level SVG canvas. Application code normally uses
+ * {@link ReactSketchCanvasProps}.
+ *
+ * @public
  */
 export interface CanvasProps {
 	/**
-	 * Array of paths to be drawn on the canvas
+	 * Paths rendered on the SVG canvas.
+	 *
+	 * @remarks
+	 * `Canvas` is controlled. Pass the complete path list for each render.
 	 */
 	paths: CanvasPath[];
 	/**
-	 * Whether the user is currently drawing
+	 * Whether a pointer stroke is currently active.
+	 *
+	 * @remarks
+	 * While this is `true`, pointer movement is forwarded to `onPointerMove`.
 	 */
 	isDrawing: boolean;
 	/**
-	 * Callback to be called when the user starts drawing.
-	 * This is triggered when the user presses the mouse button or touches the canvas
-	 * with a pen or a touch screen.
+	 * Called when the user starts a stroke.
 	 *
-	 * @param point - The point where the user started drawing
-	 * @param isEraser - Whether the user is using the eraser
-	 * @returns void
+	 * @remarks
+	 * The callback receives the pointer coordinate normalized to the canvas and
+	 * an eraser flag when a pen eraser button is detected.
+	 *
+	 * @param point - Canvas-relative point where the stroke starts.
+	 * @param isEraser - Whether the pointer should create an eraser stroke.
+	 * @returns Nothing.
 	 */
 	onPointerDown: (point: Point, isEraser?: boolean) => void;
 	/**
-	 * Callback to be called when the user is drawing.
-	 * This is triggered when the user moves the mouse or pen or finger on the canvas.
+	 * Called when the active pointer moves while drawing.
 	 *
-	 * @param point - The point where the user is currently drawing
-	 * @param isEraser - Whether the user is using the eraser
-	 * @returns void
+	 * @param point - Canvas-relative point for the current pointer position.
+	 * @returns Nothing.
 	 */
 	onPointerMove: (point: Point) => void;
 	/**
-	 * Callback to be called when the user stops drawing.
-	 * This is triggered when the user releases the mouse button or lifts the pen or finger from the canvas.
-	 * @returns void
+	 * Called when the active stroke ends.
+	 *
+	 * @remarks
+	 * `Canvas` listens for `pointerup` on the document so a stroke can finish
+	 * even when the pointer is released outside the canvas element.
+	 *
+	 * @returns Nothing.
 	 */
 	onPointerUp: () => void;
 	/**
-	 * The pointer type to allow drawing with.
-	 * @defaultValue all
+	 * Pointer device class allowed to draw on the canvas.
+	 *
+	 * @remarks
+	 * Other pointer devices can still interact with the page, but their drawing
+	 * events are ignored by the canvas.
+	 *
+	 * @defaultValue `"all"`
 	 */
 	allowOnlyPointerType: AllowOnlyPointerType;
 	/**
-	 * Background image to be displayed on the canvas.
-	 * This can be a URL or a base64 encoded image.
-	 * @defaultValue No background image is displayed
+	 * Background image shown behind all strokes.
+	 *
+	 * @remarks
+	 * Accepts any SVG `<image>` `href` value, including a URL or data URI. When
+	 * exporting with the background image enabled, remote images must allow
+	 * cross-origin access.
+	 *
+	 * @defaultValue `""`
 	 */
 	backgroundImage: string;
 	/**
-	 * Background color of the canvas.
-	 * @defaultValue white
+	 * Background color shown when no background image is configured.
+	 *
+	 * @remarks
+	 * This color is also used behind JPEG exports when the background image is
+	 * not included.
+	 *
+	 * @defaultValue `"white"`
 	 */
 	canvasColor: string;
 	/**
-	 * Class name to be applied to the canvas.
-	 * @defaultValue react-sketch-canvas
+	 * CSS class name applied to the outer canvas wrapper.
+	 *
+	 * @defaultValue `"react-sketch-canvas"`
 	 */
 	className?: string;
 	/**
-	 * Whether the canvas should be exported with the background image.
+	 * Whether exported images and SVGs include `backgroundImage`.
+	 *
+	 * @remarks
+	 * Set this to `false` when the background image is only a drawing guide and
+	 * should not be part of exported output.
+	 *
 	 * @defaultValue false
 	 */
 	exportWithBackgroundImage: boolean;
 	/**
-	 * Height of the canvas.
-	 * @defaultValue 100%
+	 * CSS height of the canvas wrapper.
+	 *
+	 * @remarks
+	 * Accepts any valid CSS height value, such as `"400px"`, `"60vh"`, or
+	 * `"100%"`.
+	 *
+	 * @defaultValue `"100%"`
 	 */
 	height: string;
 	/**
-	 * ID of the canvas.
-	 * @defaultValue the ID is `react-sketch-canvas`
+	 * Base DOM id used for the SVG canvas and generated SVG definitions.
+	 *
+	 * @remarks
+	 * Use a unique id when rendering more than one canvas on the same page.
+	 *
+	 * @defaultValue `"react-sketch-canvas"`
 	 */
 	id?: string;
 	/**
-	 * Set aspect ratio of the background image. For possible values check MDN docs
-	 * @link https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio
+	 * SVG `preserveAspectRatio` value used for `backgroundImage`.
+	 *
+	 * @remarks
+	 * See the MDN reference for accepted values:
+	 * {@link https://developer.mozilla.org/docs/Web/SVG/Attribute/preserveAspectRatio}.
+	 *
+	 * @defaultValue `"none"`
 	 */
 	preserveBackgroundImageAspectRatio?: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"];
 	/**
-	 * Style to be applied to the canvas.
-	 * @defaultValue No style is applied.
+	 * Inline styles applied to the outer canvas wrapper.
+	 *
+	 * @remarks
+	 * The component always sets `touchAction: "none"` to keep touch and pen
+	 * drawing from scrolling the page.
+	 *
+	 * @defaultValue The package default canvas border style.
 	 */
 	style: React.CSSProperties;
 	/**
-	 * Style to be applied to the SVG.
-	 * @defaultValue No style is applied.
+	 * Inline styles applied to the internal SVG element.
+	 *
+	 * @defaultValue `{}`
 	 */
 	svgStyle: React.CSSProperties;
 	/**
-	 * Whether the canvas should be exported with the viewBox.
+	 * Whether the internal SVG should include a viewBox based on the latest
+	 * measured canvas size.
+	 *
+	 * @remarks
+	 * Enable this when you need SVG output that scales predictably with the
+	 * rendered canvas dimensions.
+	 *
 	 * @defaultValue false
 	 */
 	withViewBox?: boolean;
 	/**
-	 * Width of the canvas.
-	 * @defaultValue 100%
+	 * CSS width of the canvas wrapper.
+	 *
+	 * @remarks
+	 * Accepts any valid CSS width value, such as `"600px"`, `"100%"`, or
+	 * `"80vw"`.
+	 *
+	 * @defaultValue `"100%"`
 	 */
 	width: string;
 	/**
-	 * Whether the canvas is read-only. This disables drawing on the canvas.
+	 * Whether pointer drawing is disabled.
+	 *
+	 * @remarks
+	 * Existing paths are still rendered and ref export methods still work.
+	 *
 	 * @defaultValue false
 	 */
 	readOnly?: boolean;
 }
 
 /**
- * Canvas component ref
+ * Imperative ref API exposed by the low-level {@link Canvas} component.
+ *
+ * @public
  */
 export interface CanvasRef {
 	/**
-	 * Export the canvas as an image.
-	 * This returns a promise that resolves to a data URL of the image.
+	 * Export the current canvas as a raster image data URL.
 	 *
-	 * @param imageType - The type of image to be exported.
-	 * @param options - Options to be applied to the exported image.
-	 * @returns A promise that resolves to a data URL of the image.
+	 * @remarks
+	 * The output includes the currently rendered strokes. Background image export
+	 * depends on the `exportWithBackgroundImage` prop.
+	 *
+	 * @param imageType - Image format to create.
+	 * @param options - Optional export dimensions.
+	 * @returns Promise that resolves to a `data:image/*` URL.
 	 */
 	exportImage: (
 		imageType: ExportImageType,
 		options?: ExportImageOptions,
 	) => Promise<string>;
 	/**
-	 * Export the canvas as an SVG.
-	 * This returns a promise that resolves to a string of the SVG.
+	 * Export the current canvas as SVG markup.
 	 *
-	 * @returns A promise that resolves to a string of the SVG.
+	 * @remarks
+	 * The returned string contains the cloned SVG element after export-specific
+	 * background handling has been applied.
+	 *
+	 * @returns Promise that resolves to SVG markup.
 	 */
 	exportSvg: () => Promise<string>;
 }

--- a/packages/react-sketch-canvas/src/Paths/SvgPath.tsx
+++ b/packages/react-sketch-canvas/src/Paths/SvgPath.tsx
@@ -1,0 +1,53 @@
+import type { Point } from "../types";
+import { bezierCommand } from "./geometry";
+
+export type SvgPathProps = {
+	paths: Point[];
+	id: string;
+	strokeWidth: number;
+	strokeColor: string;
+	command?: (point: Point, i: number, a: Point[]) => string;
+};
+
+export function SvgPath({
+	paths,
+	id,
+	strokeWidth,
+	strokeColor,
+	command = bezierCommand,
+}: SvgPathProps): JSX.Element {
+	if (paths.length === 1) {
+		const { x, y } = paths[0];
+		const radius = strokeWidth / 2;
+
+		return (
+			<circle
+				key={id}
+				id={id}
+				cx={x}
+				cy={y}
+				r={radius}
+				stroke={strokeColor}
+				fill={strokeColor}
+			/>
+		);
+	}
+
+	const d = paths.reduce(
+		(acc, point, i, a) =>
+			i === 0 ? `M ${point.x},${point.y}` : `${acc} ${command(point, i, a)}`,
+		"",
+	);
+
+	return (
+		<path
+			key={id}
+			id={id}
+			d={d}
+			fill="none"
+			strokeLinecap="round"
+			stroke={strokeColor}
+			strokeWidth={strokeWidth}
+		/>
+	);
+}

--- a/packages/react-sketch-canvas/src/Paths/SvgPath.tsx
+++ b/packages/react-sketch-canvas/src/Paths/SvgPath.tsx
@@ -1,14 +1,28 @@
-import type { Point } from "../types";
+import type { CanvasPath, Point } from "../types";
 import { bezierCommand } from "./geometry";
 
-export type SvgPathProps = {
-	paths: Point[];
+/**
+ * Props for rendering a single SVG stroke path.
+ *
+ * @remarks
+ * This type composes the stroke fields from {@link CanvasPath} and adds the
+ * SVG id plus an optional command generator for tests or alternate smoothing.
+ */
+export type SvgPathProps = Pick<
+	CanvasPath,
+	"paths" | "strokeWidth" | "strokeColor"
+> & {
 	id: string;
-	strokeWidth: number;
-	strokeColor: string;
 	command?: (point: Point, i: number, a: Point[]) => string;
 };
 
+/**
+ * Render one `CanvasPath` as SVG.
+ *
+ * @remarks
+ * A one-point path is rendered as a circle so taps and clicks produce visible
+ * dots. Multi-point paths are rendered as a smoothed cubic Bezier path.
+ */
 export function SvgPath({
 	paths,
 	id,

--- a/packages/react-sketch-canvas/src/Paths/geometry.ts
+++ b/packages/react-sketch-canvas/src/Paths/geometry.ts
@@ -1,0 +1,63 @@
+import type { Point } from "../types";
+
+type ControlPoints = {
+	current: Point;
+	previous?: Point;
+	next?: Point;
+	reverse?: boolean;
+};
+
+export const line = (pointA: Point, pointB: Point) => {
+	const lengthX = pointB.x - pointA.x;
+	const lengthY = pointB.y - pointA.y;
+
+	return {
+		length: Math.sqrt(lengthX ** 2 + lengthY ** 2),
+		angle: Math.atan2(lengthY, lengthX),
+	};
+};
+
+const controlPoint = (controlPoints: ControlPoints): [number, number] => {
+	const { current, next, previous, reverse } = controlPoints;
+	const p = previous || current;
+	const n = next || current;
+	const smoothing = 0.2;
+	const o = line(p, n);
+	const angle = o.angle + (reverse ? Math.PI : 0);
+	const length = o.length * smoothing;
+
+	return [
+		current.x + Math.cos(angle) * length,
+		current.y + Math.sin(angle) * length,
+	];
+};
+
+export const bezierCommand = (point: Point, i: number, a: Point[]): string => {
+	let cpsX: number;
+	let cpsY: number;
+
+	switch (i) {
+		case 0:
+			[cpsX, cpsY] = controlPoint({ current: point });
+			break;
+		case 1:
+			[cpsX, cpsY] = controlPoint({ current: a[i - 1], next: point });
+			break;
+		default:
+			[cpsX, cpsY] = controlPoint({
+				current: a[i - 1],
+				previous: a[i - 2],
+				next: point,
+			});
+			break;
+	}
+
+	const [cpeX, cpeY] = controlPoint({
+		current: point,
+		previous: a[i - 1],
+		next: a[i + 1],
+		reverse: true,
+	});
+
+	return `C ${cpsX},${cpsY} ${cpeX},${cpeY} ${point.x}, ${point.y}`;
+};

--- a/packages/react-sketch-canvas/src/Paths/geometry.ts
+++ b/packages/react-sketch-canvas/src/Paths/geometry.ts
@@ -7,7 +7,19 @@ type ControlPoints = {
 	reverse?: boolean;
 };
 
-export const line = (pointA: Point, pointB: Point) => {
+type LineReturns = {
+	length: number;
+	angle: number;
+};
+
+/**
+ * Calculate distance and angle between two points.
+ *
+ * @remarks
+ * The Bezier smoothing code uses this vector to place control points relative
+ * to neighboring stroke points.
+ */
+export const line = (pointA: Point, pointB: Point): LineReturns => {
 	const lengthX = pointB.x - pointA.x;
 	const lengthY = pointB.y - pointA.y;
 
@@ -32,6 +44,13 @@ const controlPoint = (controlPoints: ControlPoints): [number, number] => {
 	];
 };
 
+/**
+ * Create a cubic Bezier SVG command for a stroke point.
+ *
+ * @remarks
+ * The command uses the previous, current, and next points to create a smoothed
+ * freehand stroke while preserving the original point list.
+ */
 export const bezierCommand = (point: Point, i: number, a: Point[]): string => {
 	let cpsX: number;
 	let cpsY: number;

--- a/packages/react-sketch-canvas/src/Paths/index.tsx
+++ b/packages/react-sketch-canvas/src/Paths/index.tsx
@@ -7,6 +7,13 @@ type PathProps = {
 	paths: CanvasPath[];
 };
 
+/**
+ * Render an ordered list of draw-mode paths.
+ *
+ * @remarks
+ * Eraser paths are handled by SVG masks before this component receives its path
+ * group, so every path rendered here is a visible stroke.
+ */
 function Paths({ id, paths }: PathProps): JSX.Element {
 	return (
 		<>
@@ -14,8 +21,8 @@ function Paths({ id, paths }: PathProps): JSX.Element {
 				<SvgPath
 					// biome-ignore lint/suspicious/noArrayIndexKey: stroke path order is stable and has no domain id.
 					key={`${id}__${index}`}
-					paths={path.paths}
 					id={`${id}__${index}`}
+					paths={path.paths}
 					strokeWidth={path.strokeWidth}
 					strokeColor={path.strokeColor}
 					command={bezierCommand}
@@ -25,7 +32,15 @@ function Paths({ id, paths }: PathProps): JSX.Element {
 	);
 }
 
+/**
+ * Geometry helpers are exported for focused unit tests and custom path
+ * rendering experiments.
+ */
 export { bezierCommand, line } from "./geometry";
 export { SvgPath };
+
+/**
+ * Props used by the internal SVG path renderer.
+ */
 export type { SvgPathProps } from "./SvgPath";
 export default Paths;

--- a/packages/react-sketch-canvas/src/Paths/index.tsx
+++ b/packages/react-sketch-canvas/src/Paths/index.tsx
@@ -1,140 +1,11 @@
-import type { CanvasPath, Point } from "../types";
-
-type ControlPoints = {
-	current: Point;
-	previous?: Point;
-	next?: Point;
-	reverse?: boolean;
-};
+import type { CanvasPath } from "../types";
+import { SvgPath } from "./SvgPath";
+import { bezierCommand } from "./geometry";
 
 type PathProps = {
 	id: string;
 	paths: CanvasPath[];
 };
-
-export const line = (pointA: Point, pointB: Point) => {
-	const lengthX = pointB.x - pointA.x;
-	const lengthY = pointB.y - pointA.y;
-
-	return {
-		length: Math.sqrt(lengthX ** 2 + lengthY ** 2),
-		angle: Math.atan2(lengthY, lengthX),
-	};
-};
-
-const controlPoint = (controlPoints: ControlPoints): [number, number] => {
-	const { current, next, previous, reverse } = controlPoints;
-
-	const p = previous || current;
-	const n = next || current;
-
-	const smoothing = 0.2;
-
-	const o = line(p, n);
-
-	const angle = o.angle + (reverse ? Math.PI : 0);
-	const length = o.length * smoothing;
-
-	const x = current.x + Math.cos(angle) * length;
-	const y = current.y + Math.sin(angle) * length;
-
-	return [x, y];
-};
-
-export const bezierCommand = (point: Point, i: number, a: Point[]): string => {
-	let cpsX: number;
-	let cpsY: number;
-
-	switch (i) {
-		case 0:
-			[cpsX, cpsY] = controlPoint({
-				current: point,
-			});
-			break;
-		case 1:
-			[cpsX, cpsY] = controlPoint({
-				current: a[i - 1],
-				next: point,
-			});
-			break;
-		default:
-			[cpsX, cpsY] = controlPoint({
-				current: a[i - 1],
-				previous: a[i - 2],
-				next: point,
-			});
-			break;
-	}
-
-	const [cpeX, cpeY] = controlPoint({
-		current: point,
-		previous: a[i - 1],
-		next: a[i + 1],
-		reverse: true,
-	});
-
-	return `C ${cpsX},${cpsY} ${cpeX},${cpeY} ${point.x}, ${point.y}`;
-};
-
-export type SvgPathProps = {
-	// List of points to create the stroke
-	paths: Point[];
-	// Unique ID
-	id: string;
-	// Width of the stroke
-	strokeWidth: number;
-	// Color of the stroke
-	strokeColor: string;
-	// Bezier command to smoothen the line
-	command?: (point: Point, i: number, a: Point[]) => string;
-};
-
-/**
- * Generate SVG Path tag from the given points
- */
-export function SvgPath({
-	paths,
-	id,
-	strokeWidth,
-	strokeColor,
-	command = bezierCommand,
-}: SvgPathProps): JSX.Element {
-	if (paths.length === 1) {
-		const { x, y } = paths[0];
-
-		const radius = strokeWidth / 2;
-
-		return (
-			<circle
-				key={id}
-				id={id}
-				cx={x}
-				cy={y}
-				r={radius}
-				stroke={strokeColor}
-				fill={strokeColor}
-			/>
-		);
-	}
-
-	const d = paths.reduce(
-		(acc, point, i, a) =>
-			i === 0 ? `M ${point.x},${point.y}` : `${acc} ${command(point, i, a)}`,
-		"",
-	);
-
-	return (
-		<path
-			key={id}
-			id={id}
-			d={d}
-			fill="none"
-			strokeLinecap="round"
-			stroke={strokeColor}
-			strokeWidth={strokeWidth}
-		/>
-	);
-}
 
 function Paths({ id, paths }: PathProps): JSX.Element {
 	return (
@@ -154,4 +25,7 @@ function Paths({ id, paths }: PathProps): JSX.Element {
 	);
 }
 
+export { bezierCommand, line } from "./geometry";
+export { SvgPath };
+export type { SvgPathProps } from "./SvgPath";
 export default Paths;

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts
@@ -17,15 +17,19 @@ import {
 	createStroke,
 	finishStroke,
 } from "../state/strokes";
+import type { ReactSketchCanvasProps } from "../types";
 
-type UseSketchCanvasControllerParams = {
-	strokeColor: string;
-	strokeWidth: number;
-	eraserWidth: number;
-	withTimestamp: boolean;
-	onChange: (updatedPaths: CanvasPath[]) => void;
-	onStroke: (path: CanvasPath, isEraser: boolean) => void;
-};
+type UseSketchCanvasControllerParams = Required<
+	Pick<
+		ReactSketchCanvasProps,
+		| "strokeColor"
+		| "strokeWidth"
+		| "eraserWidth"
+		| "withTimestamp"
+		| "onChange"
+		| "onStroke"
+	>
+>;
 
 type UseSketchCanvasControllerReturns = {
 	currentPaths: CanvasPath[];
@@ -39,6 +43,14 @@ type UseSketchCanvasControllerReturns = {
 	handlePointerUp: () => void;
 };
 
+/**
+ * Owns state transitions for `ReactSketchCanvas`.
+ *
+ * @remarks
+ * This hook is the stateful controller for drawing, erasing, undo/redo queue
+ * processing, timestamp capture, and change callbacks. Rendering and ref
+ * methods stay in separate hooks so this logic can be unit tested directly.
+ */
 export function useSketchCanvasController({
 	strokeColor,
 	strokeWidth,
@@ -54,6 +66,8 @@ export function useSketchCanvasController({
 	const currentPaths = state.currentPaths;
 	const isDrawing = state.isDrawing;
 
+	// Keep the legacy stroke callback timing: the completed stroke is reported
+	// on the render after drawing transitions from active to inactive.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: preserve legacy stroke-lift timing tied only to drawing state changes.
 	const liftStrokeUp = React.useCallback((): void => {
 		const lastStroke = currentPaths.slice(-1)?.[0] ?? null;

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts
@@ -18,13 +18,25 @@ import {
 	finishStroke,
 } from "../state/strokes";
 
-type UseSketchCanvasControllerOptions = {
+type UseSketchCanvasControllerParams = {
 	strokeColor: string;
 	strokeWidth: number;
 	eraserWidth: number;
 	withTimestamp: boolean;
 	onChange: (updatedPaths: CanvasPath[]) => void;
 	onStroke: (path: CanvasPath, isEraser: boolean) => void;
+};
+
+type UseSketchCanvasControllerReturns = {
+	currentPaths: CanvasPath[];
+	isDrawing: boolean;
+	drawMode: boolean;
+	setEraseMode: (erase: boolean) => void;
+	enqueueOperation: (operation: Operation) => void;
+	resetCanvas: () => void;
+	handlePointerDown: (point: Point, isEraser?: boolean) => void;
+	handlePointerMove: (point: Point) => void;
+	handlePointerUp: () => void;
 };
 
 export function useSketchCanvasController({
@@ -34,7 +46,7 @@ export function useSketchCanvasController({
 	withTimestamp,
 	onChange,
 	onStroke,
-}: UseSketchCanvasControllerOptions) {
+}: UseSketchCanvasControllerParams): UseSketchCanvasControllerReturns {
 	const [state, setState] = React.useState<SketchState>(
 		createInitialSketchState,
 	);

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts
@@ -1,0 +1,160 @@
+import * as React from "react";
+import { useCallback } from "react";
+import type { CanvasPath, Point } from "../../types";
+import {
+	type SketchState,
+	addLastStrokeToHistory,
+	createInitialSketchState,
+	resetCanvasState,
+} from "../state/history";
+import {
+	type Operation,
+	applyOperation,
+	enqueueOperation as enqueueOperationInState,
+} from "../state/operations";
+import {
+	appendPointToLastStroke,
+	createStroke,
+	finishStroke,
+} from "../state/strokes";
+
+type UseSketchCanvasControllerOptions = {
+	strokeColor: string;
+	strokeWidth: number;
+	eraserWidth: number;
+	withTimestamp: boolean;
+	onChange: (updatedPaths: CanvasPath[]) => void;
+	onStroke: (path: CanvasPath, isEraser: boolean) => void;
+};
+
+export function useSketchCanvasController({
+	strokeColor,
+	strokeWidth,
+	eraserWidth,
+	withTimestamp,
+	onChange,
+	onStroke,
+}: UseSketchCanvasControllerOptions) {
+	const [state, setState] = React.useState<SketchState>(
+		createInitialSketchState,
+	);
+
+	const currentPaths = state.currentPaths;
+	const isDrawing = state.isDrawing;
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: preserve legacy stroke-lift timing tied only to drawing state changes.
+	const liftStrokeUp = React.useCallback((): void => {
+		const lastStroke = currentPaths.slice(-1)?.[0] ?? null;
+		if (lastStroke === null) return;
+
+		onStroke(lastStroke, !lastStroke.drawMode);
+	}, [isDrawing]);
+
+	React.useEffect(() => {
+		liftStrokeUp();
+	}, [liftStrokeUp]);
+
+	React.useEffect(() => {
+		onChange(currentPaths);
+	}, [currentPaths, onChange]);
+
+	React.useEffect(() => {
+		if (state.isProcessingQueue || state.operationQueue.length === 0) return;
+
+		setState((current) => {
+			if (current.isProcessingQueue || current.operationQueue.length === 0) {
+				return current;
+			}
+
+			const [operation, ...remainingQueue] = current.operationQueue;
+			const processed = applyOperation(
+				{ ...current, isProcessingQueue: true },
+				operation,
+			);
+
+			return {
+				...processed,
+				operationQueue: remainingQueue,
+				isProcessingQueue: false,
+			};
+		});
+	}, [state.isProcessingQueue, state.operationQueue]);
+
+	const enqueueOperation = useCallback((operation: Operation) => {
+		setState((current) => enqueueOperationInState(current, operation));
+	}, []);
+
+	const setEraseMode = useCallback((erase: boolean): void => {
+		setState((current) => ({ ...current, drawMode: !erase }));
+	}, []);
+
+	const resetCanvas = useCallback((): void => {
+		setState(resetCanvasState());
+	}, []);
+
+	const handlePointerDown = useCallback(
+		(point: Point, isEraser = false): void => {
+			setState((current) => {
+				const synced = addLastStrokeToHistory(current);
+				const isDraw = !isEraser && synced.drawMode;
+				const stroke = createStroke({
+					point,
+					drawMode: isDraw,
+					strokeColor,
+					strokeWidth,
+					eraserWidth,
+					withTimestamp,
+					now: Date.now(),
+				});
+
+				return {
+					...synced,
+					isDrawing: true,
+					historyPos: synced.historyPos + 1,
+					historySynced: false,
+					currentPaths: [...synced.currentPaths, stroke],
+				};
+			});
+		},
+		[eraserWidth, strokeColor, strokeWidth, withTimestamp],
+	);
+
+	const handlePointerMove = useCallback((point: Point): void => {
+		setState((current) => {
+			if (!current.isDrawing) return current;
+
+			return {
+				...current,
+				currentPaths: appendPointToLastStroke(current.currentPaths, point),
+			};
+		});
+	}, []);
+
+	const handlePointerUp = useCallback((): void => {
+		setState((current) => {
+			if (!current.isDrawing) return current;
+
+			return {
+				...current,
+				isDrawing: false,
+				currentPaths: finishStroke(
+					current.currentPaths,
+					withTimestamp,
+					Date.now(),
+				),
+			};
+		});
+	}, [withTimestamp]);
+
+	return {
+		currentPaths,
+		isDrawing,
+		drawMode: state.drawMode,
+		setEraseMode,
+		enqueueOperation,
+		resetCanvas,
+		handlePointerDown,
+		handlePointerMove,
+		handlePointerUp,
+	};
+}

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasImperativeHandle.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasImperativeHandle.ts
@@ -1,0 +1,88 @@
+import * as React from "react";
+import type { CanvasRef } from "../../Canvas/types";
+import type {
+	CanvasPath,
+	ExportImageOptions,
+	ExportImageType,
+} from "../../types";
+import type { Operation } from "../state/operations";
+import { getSketchingTime } from "../state/sketchingTime";
+import type { ReactSketchCanvasRef } from "../types";
+
+type UseSketchCanvasImperativeHandleOptions = {
+	canvasRef: React.RefObject<CanvasRef>;
+	currentPaths: CanvasPath[];
+	withTimestamp: boolean;
+	setEraseMode: (erase: boolean) => void;
+	enqueueOperation: (operation: Operation) => void;
+	resetCanvas: () => void;
+};
+
+export function useSketchCanvasImperativeHandle(
+	ref: React.ForwardedRef<ReactSketchCanvasRef>,
+	{
+		canvasRef,
+		currentPaths,
+		withTimestamp,
+		setEraseMode,
+		enqueueOperation,
+		resetCanvas,
+	}: UseSketchCanvasImperativeHandleOptions,
+): void {
+	React.useImperativeHandle(
+		ref,
+		() => ({
+			eraseMode: setEraseMode,
+			clearCanvas: (): void => {
+				enqueueOperation({ type: "clear" });
+			},
+			undo: (): void => {
+				enqueueOperation({ type: "undo" });
+			},
+			redo: (): void => {
+				enqueueOperation({ type: "redo" });
+			},
+			exportImage: (
+				imageType: ExportImageType,
+				options?: ExportImageOptions,
+			): Promise<string> => {
+				const exportImage = canvasRef.current?.exportImage;
+
+				if (!exportImage) {
+					throw Error("Export function called before canvas loaded");
+				}
+
+				return exportImage(imageType, options);
+			},
+			exportSvg: async (): Promise<string> => {
+				const exportSvg = canvasRef.current?.exportSvg;
+
+				if (!exportSvg) {
+					throw Error("Export function called before canvas loaded");
+				}
+
+				return exportSvg();
+			},
+			exportPaths: async (): Promise<CanvasPath[]> => currentPaths,
+			loadPaths: (paths: CanvasPath[]): void => {
+				enqueueOperation({ type: "loadPaths", payload: paths });
+			},
+			getSketchingTime: async (): Promise<number> => {
+				if (!withTimestamp) {
+					throw new Error("Set 'withTimestamp' prop to get sketching time");
+				}
+
+				return getSketchingTime(currentPaths);
+			},
+			resetCanvas,
+		}),
+		[
+			canvasRef,
+			currentPaths,
+			enqueueOperation,
+			resetCanvas,
+			setEraseMode,
+			withTimestamp,
+		],
+	);
+}

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasImperativeHandle.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasImperativeHandle.ts
@@ -20,6 +20,13 @@ type UseSketchCanvasImperativeHandleParams = {
 
 type UseSketchCanvasImperativeHandleReturns = ReturnType<() => void>;
 
+/**
+ * Expose the public `ReactSketchCanvas` imperative API.
+ *
+ * @remarks
+ * This hook adapts the low-level canvas export ref and the state controller into
+ * the user-facing methods documented by `ReactSketchCanvasRef`.
+ */
 export function useSketchCanvasImperativeHandle(
 	ref: React.ForwardedRef<ReactSketchCanvasRef>,
 	{

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasImperativeHandle.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasImperativeHandle.ts
@@ -9,7 +9,7 @@ import type { Operation } from "../state/operations";
 import { getSketchingTime } from "../state/sketchingTime";
 import type { ReactSketchCanvasRef } from "../types";
 
-type UseSketchCanvasImperativeHandleOptions = {
+type UseSketchCanvasImperativeHandleParams = {
 	canvasRef: React.RefObject<CanvasRef>;
 	currentPaths: CanvasPath[];
 	withTimestamp: boolean;
@@ -17,6 +17,8 @@ type UseSketchCanvasImperativeHandleOptions = {
 	enqueueOperation: (operation: Operation) => void;
 	resetCanvas: () => void;
 };
+
+type UseSketchCanvasImperativeHandleReturns = ReturnType<() => void>;
 
 export function useSketchCanvasImperativeHandle(
 	ref: React.ForwardedRef<ReactSketchCanvasRef>,
@@ -27,8 +29,8 @@ export function useSketchCanvasImperativeHandle(
 		setEraseMode,
 		enqueueOperation,
 		resetCanvas,
-	}: UseSketchCanvasImperativeHandleOptions,
-): void {
+	}: UseSketchCanvasImperativeHandleParams,
+): UseSketchCanvasImperativeHandleReturns {
 	React.useImperativeHandle(
 		ref,
 		() => ({

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx
@@ -1,19 +1,10 @@
 import * as React from "react";
-import { useCallback } from "react";
 import { Canvas } from "../Canvas";
 import type { CanvasRef } from "../Canvas/types";
-import type {
-	CanvasPath,
-	ExportImageOptions,
-	ExportImageType,
-	Point,
-} from "../types";
+import type { CanvasPath } from "../types";
+import { useSketchCanvasController } from "./hooks/useSketchCanvasController";
+import { useSketchCanvasImperativeHandle } from "./hooks/useSketchCanvasImperativeHandle";
 import type { ReactSketchCanvasProps, ReactSketchCanvasRef } from "./types";
-
-type Operation = {
-	type: "undo" | "redo" | "clear" | "loadPaths";
-	payload?: CanvasPath[];
-};
 
 /**
  * ReactSketchCanvas is a wrapper around Canvas component to provide a controlled way to manage the canvas paths.
@@ -54,249 +45,32 @@ export const ReactSketchCanvas = React.forwardRef<
 	} = props;
 
 	const svgCanvas = React.createRef<CanvasRef>();
-	const [drawMode, setDrawMode] = React.useState<boolean>(true);
-	const [isDrawing, setIsDrawing] = React.useState<boolean>(false);
-	const [history, setHistory] = React.useState<CanvasPath[][]>([[]]);
-	const [historyPos, setHistoryPos] = React.useState<number>(0);
-	const [historySynced, setHistorySynced] = React.useState<boolean>(false);
-	const [currentPaths, setCurrentPaths] = React.useState<CanvasPath[]>([]);
-	const [operationQueue, setOperationQueue] = React.useState<Operation[]>([]);
-	const [isProcessingQueue, setIsProcessingQueue] = React.useState(false);
+	const {
+		currentPaths,
+		isDrawing,
+		enqueueOperation,
+		resetCanvas,
+		setEraseMode,
+		handlePointerDown,
+		handlePointerMove,
+		handlePointerUp,
+	} = useSketchCanvasController({
+		strokeColor,
+		strokeWidth,
+		eraserWidth,
+		withTimestamp,
+		onChange,
+		onStroke,
+	});
 
-	const addLastStroke = useCallback((): void => {
-		if (!historySynced) {
-			setHistory((his) => [...his.slice(0, historyPos), [...currentPaths]]);
-			setHistorySynced(true);
-		}
-	}, [currentPaths, historyPos, historySynced]);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: preserve legacy stroke-lift timing tied only to drawing state changes.
-	const liftStrokeUp = React.useCallback((): void => {
-		const lastStroke = currentPaths.slice(-1)?.[0] ?? null;
-
-		if (lastStroke === null) {
-			return;
-		}
-
-		onStroke(lastStroke, !lastStroke.drawMode);
-	}, [isDrawing]);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: preserve legacy effect timing tied only to drawing state changes.
-	React.useEffect(() => {
-		liftStrokeUp();
-	}, [isDrawing]);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: preserve legacy change notification behavior.
-	React.useEffect(() => {
-		onChange(currentPaths);
-	}, [currentPaths]);
-
-	const processQueue = React.useCallback(async () => {
-		if (isProcessingQueue || operationQueue.length === 0) return;
-
-		setIsProcessingQueue(true);
-		const operation = operationQueue[0];
-
-		try {
-			switch (operation.type) {
-				case "undo":
-					if (historyPos > 0) {
-						addLastStroke();
-						setCurrentPaths(history[historyPos - 1]);
-						setHistoryPos((pos) => pos - 1);
-					}
-					break;
-				case "redo":
-					if (historyPos < history.length - 1) {
-						addLastStroke();
-						setCurrentPaths(history[historyPos + 1]);
-						setHistoryPos((pos) => pos + 1);
-					}
-					break;
-				case "clear":
-					addLastStroke();
-					setCurrentPaths([]);
-					setHistory((his) => [...his.slice(0, historyPos + 1), []]);
-					setHistoryPos((pos) => pos + 1);
-					break;
-				case "loadPaths":
-					if (operation.payload) {
-						const { payload } = operation;
-						addLastStroke();
-						setCurrentPaths((paths) => {
-							const newPaths = [...paths, ...payload];
-							setHistory((his) => {
-								const newHistoryPos = historyPos + 1;
-								setHistoryPos(newHistoryPos);
-								return [...his.slice(0, newHistoryPos), newPaths];
-							});
-							return newPaths;
-						});
-					}
-					break;
-				default:
-					throw new Error(`Unknown operation type: ${operation.type}`);
-			}
-		} finally {
-			setOperationQueue((queue) => queue.slice(1));
-			setIsProcessingQueue(false);
-		}
-	}, [operationQueue, isProcessingQueue, historyPos, history, addLastStroke]);
-
-	React.useEffect(() => {
-		processQueue();
-	}, [processQueue]);
-
-	const enqueueOperation = useCallback((operation: Operation) => {
-		setOperationQueue((queue) => [...queue, operation]);
-	}, []);
-
-	React.useImperativeHandle(
-		ref,
-		() => ({
-			eraseMode: (erase: boolean): void => {
-				setDrawMode(!erase);
-			},
-			clearCanvas: (): void => {
-				enqueueOperation({ type: "clear" });
-			},
-			undo: (): void => {
-				enqueueOperation({ type: "undo" });
-			},
-			redo: (): void => {
-				enqueueOperation({ type: "redo" });
-			},
-			exportImage: (
-				imageType: ExportImageType,
-				options?: ExportImageOptions,
-			): Promise<string> => {
-				const exportImage = svgCanvas.current?.exportImage;
-
-				if (!exportImage) {
-					throw Error("Export function called before canvas loaded");
-				}
-
-				return exportImage(imageType, options);
-			},
-			exportSvg: (): Promise<string> =>
-				new Promise<string>((resolve, reject) => {
-					const exportSvg = svgCanvas.current?.exportSvg;
-
-					if (!exportSvg) {
-						reject(Error("Export function called before canvas loaded"));
-					} else {
-						exportSvg()
-							.then((data) => {
-								resolve(data);
-							})
-							.catch((e) => {
-								reject(e);
-							});
-					}
-				}),
-			exportPaths: (): Promise<CanvasPath[]> =>
-				new Promise<CanvasPath[]>((resolve, reject) => {
-					try {
-						resolve(currentPaths);
-					} catch (e) {
-						reject(e);
-					}
-				}),
-			loadPaths: (paths: CanvasPath[]): void => {
-				enqueueOperation({ type: "loadPaths", payload: paths });
-			},
-			getSketchingTime: (): Promise<number> =>
-				new Promise<number>((resolve, reject) => {
-					if (!withTimestamp) {
-						reject(new Error("Set 'withTimestamp' prop to get sketching time"));
-					}
-
-					try {
-						const sketchingTime = currentPaths.reduce(
-							(totalSketchingTime, path) => {
-								const startTimestamp = path.startTimestamp ?? 0;
-								const endTimestamp = path.endTimestamp ?? 0;
-
-								return totalSketchingTime + (endTimestamp - startTimestamp);
-							},
-							0,
-						);
-
-						resolve(sketchingTime);
-					} catch (e) {
-						reject(e);
-					}
-				}),
-			resetCanvas: (): void => {
-				setHistory([]);
-				setHistoryPos(0);
-				setCurrentPaths([]);
-				setOperationQueue([]);
-			},
-		}),
-		[currentPaths, svgCanvas, withTimestamp, enqueueOperation],
-	);
-
-	const handlePointerDown = (point: Point, isEraser = false): void => {
-		setIsDrawing(true);
-
-		const isDraw = !isEraser && drawMode;
-
-		let stroke: CanvasPath = {
-			drawMode: isDraw,
-			strokeColor: isDraw ? strokeColor : "#000000", // Eraser using mask
-			strokeWidth: isDraw ? strokeWidth : eraserWidth,
-			paths: [point],
-		};
-
-		if (withTimestamp) {
-			stroke = {
-				...stroke,
-				startTimestamp: Date.now(),
-				endTimestamp: 0,
-			};
-		}
-		addLastStroke();
-		setHistoryPos((pos) => pos + 1);
-		setHistorySynced(false);
-		setCurrentPaths((paths) => [...paths, stroke]);
-	};
-
-	const handlePointerMove = (point: Point): void => {
-		if (!isDrawing) return;
-
-		const currentStroke = currentPaths.slice(-1)[0];
-		const updatedStroke = {
-			...currentStroke,
-			paths: [...currentStroke.paths, point],
-		};
-		setCurrentPaths((paths) => [...paths.slice(0, -1), updatedStroke]);
-	};
-
-	const handlePointerUp = (): void => {
-		if (!isDrawing) {
-			return;
-		}
-
-		const currentStroke = currentPaths.slice(-1)?.[0] ?? null;
-
-		setIsDrawing(false);
-
-		if (!withTimestamp) {
-			return;
-		}
-
-		if (currentStroke === null) {
-			return;
-		}
-
-		const updatedStroke = {
-			...currentStroke,
-			endTimestamp: Date.now(),
-		};
-
-		setCurrentPaths((paths) => [...paths.slice(0, -1), updatedStroke]);
-	};
+	useSketchCanvasImperativeHandle(ref, {
+		canvasRef: svgCanvas,
+		currentPaths,
+		withTimestamp,
+		setEraseMode,
+		enqueueOperation,
+		resetCanvas,
+	});
 
 	return (
 		<Canvas

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx
@@ -7,15 +7,34 @@ import { useSketchCanvasImperativeHandle } from "./hooks/useSketchCanvasImperati
 import type { ReactSketchCanvasProps, ReactSketchCanvasRef } from "./types";
 
 /**
- * ReactSketchCanvas is a wrapper around Canvas component to provide a controlled way to manage the canvas paths.
- * It provides a set of methods to manage the canvas paths, undo, redo, clear and reset the canvas.
+ * Type of the stateful sketch canvas component.
  *
- * @param props - Props for the ReactSketchCanvas component
- * @param ref - Reference to the ReactSketchCanvas component
- *
- * @returns ReactSketchCanvas component
+ * @remarks
+ * Keeping this explicit makes the generated declarations show the composed
+ * props and ref types used by the public React component.
  */
-export const ReactSketchCanvas = React.forwardRef<
+type ReactSketchCanvasComponent = React.ForwardRefExoticComponent<
+	ReactSketchCanvasProps & React.RefAttributes<ReactSketchCanvasRef>
+>;
+
+/**
+ * Stateful sketch canvas component for freehand SVG drawing.
+ *
+ * @remarks
+ * `ReactSketchCanvas` manages paths, draw/erase mode, undo/redo history,
+ * timestamp capture, and public imperative methods. It is the primary component
+ * intended for application use.
+ *
+ * Use a ref when you need to export images or paths, toggle erasing from a
+ * toolbar, or control history from parent UI.
+ *
+ * @param props - Public drawing, styling, export, and callback options.
+ * @param ref - Ref exposing {@link ReactSketchCanvasRef} methods.
+ * @returns The sketch canvas component.
+ *
+ * @public
+ */
+export const ReactSketchCanvas: ReactSketchCanvasComponent = React.forwardRef<
 	ReactSketchCanvasRef,
 	ReactSketchCanvasProps
 >((props, ref) => {

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/state/history.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/state/history.ts
@@ -1,0 +1,95 @@
+import type { CanvasPath } from "../../types";
+import type { Operation } from "./operations";
+
+export type SketchState = {
+	drawMode: boolean;
+	isDrawing: boolean;
+	history: CanvasPath[][];
+	historyPos: number;
+	historySynced: boolean;
+	currentPaths: CanvasPath[];
+	operationQueue: Operation[];
+	isProcessingQueue: boolean;
+};
+
+export function createInitialSketchState(): SketchState {
+	return {
+		drawMode: true,
+		isDrawing: false,
+		history: [[]],
+		historyPos: 0,
+		historySynced: false,
+		currentPaths: [],
+		operationQueue: [],
+		isProcessingQueue: false,
+	};
+}
+
+export function addLastStrokeToHistory(state: SketchState): SketchState {
+	if (state.historySynced) return state;
+
+	return {
+		...state,
+		history: [
+			...state.history.slice(0, state.historyPos),
+			[...state.currentPaths],
+		],
+		historySynced: true,
+	};
+}
+
+export function undoState(state: SketchState): SketchState {
+	if (state.historyPos <= 0) return state;
+	const synced = addLastStrokeToHistory(state);
+
+	return {
+		...synced,
+		currentPaths: synced.history[synced.historyPos - 1],
+		historyPos: synced.historyPos - 1,
+	};
+}
+
+export function redoState(state: SketchState): SketchState {
+	if (state.historyPos >= state.history.length - 1) return state;
+	const synced = addLastStrokeToHistory(state);
+
+	return {
+		...synced,
+		currentPaths: synced.history[synced.historyPos + 1],
+		historyPos: synced.historyPos + 1,
+	};
+}
+
+export function clearCanvasState(state: SketchState): SketchState {
+	const synced = addLastStrokeToHistory(state);
+
+	return {
+		...synced,
+		currentPaths: [],
+		history: [...synced.history.slice(0, synced.historyPos + 1), []],
+		historyPos: synced.historyPos + 1,
+	};
+}
+
+export function loadPathsState(
+	state: SketchState,
+	paths: CanvasPath[],
+): SketchState {
+	const synced = addLastStrokeToHistory(state);
+	const newPaths = [...synced.currentPaths, ...paths];
+	const newHistoryPos = synced.historyPos + 1;
+
+	return {
+		...synced,
+		currentPaths: newPaths,
+		history: [...synced.history.slice(0, newHistoryPos), newPaths],
+		historyPos: newHistoryPos,
+	};
+}
+
+export function resetCanvasState(): SketchState {
+	return {
+		...createInitialSketchState(),
+		history: [],
+	};
+}

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/state/history.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/state/history.ts
@@ -1,6 +1,14 @@
 import type { CanvasPath } from "../../types";
 import type { Operation } from "./operations";
 
+/**
+ * Internal state model for `ReactSketchCanvas`.
+ *
+ * @remarks
+ * `currentPaths` is the rendered drawing. `history` stores snapshots for
+ * undo/redo. `operationQueue` serializes imperative ref operations so multiple
+ * calls in the same render cycle are applied in order.
+ */
 export type SketchState = {
 	drawMode: boolean;
 	isDrawing: boolean;
@@ -12,6 +20,9 @@ export type SketchState = {
 	isProcessingQueue: boolean;
 };
 
+/**
+ * Create the initial interactive drawing state.
+ */
 export function createInitialSketchState(): SketchState {
 	return {
 		drawMode: true,
@@ -25,6 +36,14 @@ export function createInitialSketchState(): SketchState {
 	};
 }
 
+/**
+ * Persist the current path list into history when it has not been synced yet.
+ *
+ * @remarks
+ * Drawing mutates `currentPaths` first. History is synced lazily before the next
+ * history operation so continuous pointer updates do not create one history
+ * entry per point.
+ */
 export function addLastStrokeToHistory(state: SketchState): SketchState {
 	if (state.historySynced) return state;
 
@@ -38,6 +57,9 @@ export function addLastStrokeToHistory(state: SketchState): SketchState {
 	};
 }
 
+/**
+ * Move the state one step backward in history.
+ */
 export function undoState(state: SketchState): SketchState {
 	if (state.historyPos <= 0) return state;
 	const synced = addLastStrokeToHistory(state);
@@ -49,6 +71,9 @@ export function undoState(state: SketchState): SketchState {
 	};
 }
 
+/**
+ * Move the state one step forward in history.
+ */
 export function redoState(state: SketchState): SketchState {
 	if (state.historyPos >= state.history.length - 1) return state;
 	const synced = addLastStrokeToHistory(state);
@@ -60,6 +85,9 @@ export function redoState(state: SketchState): SketchState {
 	};
 }
 
+/**
+ * Clear rendered paths while preserving undo history.
+ */
 export function clearCanvasState(state: SketchState): SketchState {
 	const synced = addLastStrokeToHistory(state);
 
@@ -71,6 +99,9 @@ export function clearCanvasState(state: SketchState): SketchState {
 	};
 }
 
+/**
+ * Append externally supplied paths and add the result to history.
+ */
 export function loadPathsState(
 	state: SketchState,
 	paths: CanvasPath[],
@@ -87,6 +118,9 @@ export function loadPathsState(
 	};
 }
 
+/**
+ * Reset paths, history, drawing mode, and queued operations to a fresh canvas.
+ */
 export function resetCanvasState(): SketchState {
 	return {
 		...createInitialSketchState(),

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/state/operations.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/state/operations.ts
@@ -7,11 +7,17 @@ import {
 	undoState,
 } from "./history";
 
+/**
+ * Queued imperative operation requested through `ReactSketchCanvasRef`.
+ */
 export type Operation = {
 	type: "undo" | "redo" | "clear" | "loadPaths";
 	payload?: CanvasPath[];
 };
 
+/**
+ * Add an imperative operation to the end of the state queue.
+ */
 export function enqueueOperation(
 	state: SketchState,
 	operation: Operation,
@@ -22,6 +28,13 @@ export function enqueueOperation(
 	};
 }
 
+/**
+ * Apply a queued operation to sketch state.
+ *
+ * @remarks
+ * Keeping this function pure makes imperative behavior easy to test without
+ * rendering React components.
+ */
 export function applyOperation(
 	state: SketchState,
 	operation: Operation,

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/state/operations.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/state/operations.ts
@@ -1,0 +1,45 @@
+import type { CanvasPath } from "../../types";
+import type { SketchState } from "./history";
+import {
+	clearCanvasState,
+	loadPathsState,
+	redoState,
+	undoState,
+} from "./history";
+
+export type Operation = {
+	type: "undo" | "redo" | "clear" | "loadPaths";
+	payload?: CanvasPath[];
+};
+
+export function enqueueOperation(
+	state: SketchState,
+	operation: Operation,
+): SketchState {
+	return {
+		...state,
+		operationQueue: [...state.operationQueue, operation],
+	};
+}
+
+export function applyOperation(
+	state: SketchState,
+	operation: Operation,
+): SketchState {
+	switch (operation.type) {
+		case "undo":
+			return undoState(state);
+		case "redo":
+			return redoState(state);
+		case "clear":
+			return clearCanvasState(state);
+		case "loadPaths":
+			return operation.payload
+				? loadPathsState(state, operation.payload)
+				: state;
+		default:
+			throw new Error(
+				`Unknown operation type: ${(operation as Operation).type}`,
+			);
+	}
+}

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/state/sketchingTime.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/state/sketchingTime.ts
@@ -1,0 +1,10 @@
+import type { CanvasPath } from "../../types";
+
+export function getSketchingTime(paths: CanvasPath[]): number {
+	return paths.reduce((totalSketchingTime, path) => {
+		const startTimestamp = path.startTimestamp ?? 0;
+		const endTimestamp = path.endTimestamp ?? 0;
+
+		return totalSketchingTime + (endTimestamp - startTimestamp);
+	}, 0);
+}

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/state/sketchingTime.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/state/sketchingTime.ts
@@ -1,5 +1,13 @@
 import type { CanvasPath } from "../../types";
 
+/**
+ * Sum active drawing time from timestamped paths.
+ *
+ * @remarks
+ * Missing timestamps count as zero so callers can safely pass mixed imported
+ * path data. Public callers should enable `withTimestamp` before drawing if
+ * they need a meaningful result.
+ */
 export function getSketchingTime(paths: CanvasPath[]): number {
 	return paths.reduce((totalSketchingTime, path) => {
 		const startTimestamp = path.startTimestamp ?? 0;

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/state/strokes.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/state/strokes.ts
@@ -12,6 +12,13 @@ type CreateStrokeParams = {
 
 type CreateStrokeReturns = CanvasPath;
 
+/**
+ * Create the first path object for a new draw or erase stroke.
+ *
+ * @remarks
+ * Eraser strokes are stored as black paths with `drawMode: false`; SVG mask
+ * rendering interprets that shape as erased content later.
+ */
 export function createStroke({
 	point,
 	drawMode,
@@ -39,6 +46,9 @@ export function createStroke({
 	};
 }
 
+/**
+ * Add a point to the most recent stroke without mutating existing path arrays.
+ */
 export function appendPointToLastStroke(
 	paths: CanvasPath[],
 	point: Point,
@@ -57,6 +67,9 @@ export function appendPointToLastStroke(
 	return [...paths.slice(0, -1), updatedStroke];
 }
 
+/**
+ * Mark the most recent stroke as complete when timestamp tracking is enabled.
+ */
 export function finishStroke(
 	paths: CanvasPath[],
 	withTimestamp: boolean,

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/state/strokes.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/state/strokes.ts
@@ -1,6 +1,6 @@
 import type { CanvasPath, Point } from "../../types";
 
-type CreateStrokeOptions = {
+type CreateStrokeParams = {
 	point: Point;
 	drawMode: boolean;
 	strokeColor: string;
@@ -10,6 +10,8 @@ type CreateStrokeOptions = {
 	now: number;
 };
 
+type CreateStrokeReturns = CanvasPath;
+
 export function createStroke({
 	point,
 	drawMode,
@@ -18,7 +20,7 @@ export function createStroke({
 	eraserWidth,
 	withTimestamp,
 	now,
-}: CreateStrokeOptions): CanvasPath {
+}: CreateStrokeParams): CreateStrokeReturns {
 	const stroke: CanvasPath = {
 		drawMode,
 		strokeColor: drawMode ? strokeColor : "#000000",

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/state/strokes.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/state/strokes.ts
@@ -1,0 +1,74 @@
+import type { CanvasPath, Point } from "../../types";
+
+type CreateStrokeOptions = {
+	point: Point;
+	drawMode: boolean;
+	strokeColor: string;
+	strokeWidth: number;
+	eraserWidth: number;
+	withTimestamp: boolean;
+	now: number;
+};
+
+export function createStroke({
+	point,
+	drawMode,
+	strokeColor,
+	strokeWidth,
+	eraserWidth,
+	withTimestamp,
+	now,
+}: CreateStrokeOptions): CanvasPath {
+	const stroke: CanvasPath = {
+		drawMode,
+		strokeColor: drawMode ? strokeColor : "#000000",
+		strokeWidth: drawMode ? strokeWidth : eraserWidth,
+		paths: [point],
+	};
+
+	if (!withTimestamp) {
+		return stroke;
+	}
+
+	return {
+		...stroke,
+		startTimestamp: now,
+		endTimestamp: 0,
+	};
+}
+
+export function appendPointToLastStroke(
+	paths: CanvasPath[],
+	point: Point,
+): CanvasPath[] {
+	const currentStroke = paths.slice(-1)[0];
+
+	if (!currentStroke) {
+		return paths;
+	}
+
+	const updatedStroke = {
+		...currentStroke,
+		paths: [...currentStroke.paths, point],
+	};
+
+	return [...paths.slice(0, -1), updatedStroke];
+}
+
+export function finishStroke(
+	paths: CanvasPath[],
+	withTimestamp: boolean,
+	now: number,
+): CanvasPath[] {
+	if (!withTimestamp) return paths;
+
+	const currentStroke = paths.slice(-1)?.[0] ?? null;
+	if (currentStroke === null) return paths;
+
+	const updatedStroke = {
+		...currentStroke,
+		endTimestamp: now,
+	};
+
+	return [...paths.slice(0, -1), updatedStroke];
+}

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts
@@ -1,12 +1,16 @@
-/* Props validation */
 import type { CanvasProps, CanvasRef } from "../Canvas/types";
 import type { CanvasPath } from "../types";
 
 /**
- * React Sketch Canvas component props.
+ * Props for the stateful {@link ReactSketchCanvas} component.
  *
  * @remarks
- * This is an extension of the CanvasProps with additional props specific to the React Sketch Canvas component.
+ * `ReactSketchCanvas` composes the low-level {@link CanvasProps} with drawing
+ * state management. You can pass sizing, styling, background, pointer, and
+ * export props from `CanvasProps`; path state and pointer callbacks are managed
+ * internally by the component.
+ *
+ * @public
  */
 export interface ReactSketchCanvasProps
 	extends Partial<
@@ -16,51 +20,65 @@ export interface ReactSketchCanvasProps
 		>
 	> {
 	/**
-	 * Width of the eraser.
-	 * @remarks This is only applicable when the eraseMode is set to true.
+	 * Width of eraser strokes in pixels.
 	 *
-	 * @defaultValue 8
+	 * @remarks
+	 * This width is used when `eraseMode(true)` is active or when a pen eraser
+	 * button is detected.
+	 *
+	 * @defaultValue `8`
 	 */
 	eraserWidth?: number;
 	/**
-	 * Optional callback that is called when the user starts drawing.
-	 * This is triggered when the user when user creates a stroke on the canvas
-	 * with a pen or an eraser.
+	 * Called whenever the rendered path list changes.
 	 *
-	 * @param updatedPaths - The updated paths drawn on the canvas
+	 * @remarks
+	 * Use this callback to persist drawings as the user sketches. The callback is
+	 * invoked after strokes, undo, redo, clear, reset, and `loadPaths` updates.
+	 *
+	 * @param updatedPaths - Complete current path list.
+	 * @returns Nothing.
 	 */
 	onChange?: (updatedPaths: CanvasPath[]) => void;
 	/**
-	 * Optional callback that is called when the user creates a stroke on the canvas
-	 * with a pen or an eraser.
+	 * Called when the user completes a stroke.
 	 *
-	 * @param path - The path drawn on the canvas
-	 * @param isEraser - Whether the user is using the eraser
+	 * @remarks
+	 * This callback fires for both drawing and erasing strokes. It is intended
+	 * for event-style handling; use `onChange` when you need the complete drawing
+	 * state.
+	 *
+	 * @param path - Stroke that was just completed.
+	 * @param isEraser - Whether the completed stroke erased existing content.
+	 * @returns Nothing.
 	 */
 	onStroke?: (path: CanvasPath, isEraser: boolean) => void;
 	/**
-	 * Color of the stroke.
+	 * Color used for drawing strokes.
 	 *
-	 * @remarks This is only applicable when the eraseMode is set to false.
+	 * @remarks
+	 * Accepts any SVG stroke color value, including named colors, hex colors,
+	 * RGB values, and CSS variables.
 	 *
 	 * @defaultValue "red"
 	 */
 	strokeColor?: string;
 	/**
-	 * Width of the stroke.
+	 * Width of drawing strokes in pixels.
 	 *
-	 * @remarks This is only applicable when the eraseMode is set to false.
+	 * @remarks
+	 * Eraser strokes use `eraserWidth` instead.
 	 *
-	 * @defaultValue 4
+	 * @defaultValue `4`
 	 */
 	strokeWidth?: number;
 	/**
-	 * Whether to record the timestamp of the drawing. This will be stored in
-	 * the CanvasPath object in milliseconds. This can be used to calculate the time taken to draw
-	 * on the canvas.
+	 * Whether strokes should include start and end timestamps.
 	 *
 	 * @remarks
-	 * use getSketchingTime method to get the time taken to draw on the canvas.
+	 * Enable this before drawing if you want `CanvasPath.startTimestamp`,
+	 * `CanvasPath.endTimestamp`, and `getSketchingTime()` to report active
+	 * drawing time.
 	 *
 	 * @defaultValue false
 	 */
@@ -68,60 +86,95 @@ export interface ReactSketchCanvasProps
 }
 
 /**
- * React Sketch Canvas component ref.
+ * Imperative ref API exposed by {@link ReactSketchCanvas}.
  *
  * @remarks
- * This is an extension of the CanvasRef with additional methods specific to the React Sketch Canvas component.
+ * Use this ref to control drawing mode, history, exports, and path loading
+ * from parent components.
+ *
+ * @public
  */
 export interface ReactSketchCanvasRef extends CanvasRef {
 	/**
-	 * Set the drawing mode to either draw or erase
+	 * Switch between drawing and erasing.
 	 *
-	 * @param erase - Whether to set the mode to erase
+	 * @remarks
+	 * Passing `true` enables erasing for future strokes. Passing `false` returns
+	 * to normal drawing mode. Existing paths are not changed.
+	 *
+	 * @param erase - Whether future pointer strokes should erase.
+	 * @returns Nothing.
 	 */
 	eraseMode: (erase: boolean) => void;
 	/**
-	 * Clear the canvas. This will remove all the paths drawn on the canvas.
-	 * But it will not clear the Undo/Redo stack.
+	 * Remove all paths from the canvas while preserving history.
 	 *
-	 * @remarks To clear the Undo/Redo stack, use the resetCanvas method.
+	 * @remarks
+	 * Users can still undo back to the previous drawing after `clearCanvas()`.
+	 * Use `resetCanvas()` when you want to remove paths and clear undo/redo
+	 * history.
+	 *
+	 * @returns Nothing.
 	 */
 	clearCanvas: () => void;
 	/**
-	 * Undo the last drawn path
+	 * Restore the previous history entry.
+	 *
+	 * @remarks
+	 * Calling `undo()` when there is no earlier history entry leaves the canvas
+	 * unchanged.
+	 *
+	 * @returns Nothing.
 	 */
 	undo: () => void;
 	/**
-	 * Redo the last undone path
+	 * Restore the next history entry after an undo.
+	 *
+	 * @remarks
+	 * Calling `redo()` when there is no later history entry leaves the canvas
+	 * unchanged.
+	 *
+	 * @returns Nothing.
 	 */
 	redo: () => void;
 	/**
-	 * Export the paths draw on the canvas as a JSON object with list of CanvasPaths
+	 * Export the current path data.
 	 *
-	 * @returns Promise<CanvasPath[]> - The paths drawn on the canvas
+	 * @remarks
+	 * The returned paths can be stored and later passed to `loadPaths()`.
+	 *
+	 * @returns Promise that resolves with the current path list.
 	 */
 	exportPaths: () => Promise<CanvasPath[]>;
 	/**
-	 * Import the paths to be drawn on the canvas.
+	 * Append paths to the canvas.
 	 *
 	 * @remarks
-	 * This will remove all the existing paths on the canvas and replace them with the new paths.
+	 * Existing paths are preserved. The provided paths are appended to the end
+	 * of the current path list and become part of undo/redo history.
 	 *
-	 * @param paths - The paths to be drawn on the canvas
+	 * @param paths - Paths to append to the current drawing.
+	 * @returns Nothing.
 	 */
 	loadPaths: (paths: CanvasPath[]) => void;
 	/**
-	 * Get the current drawing time in milliseconds. This will only work if withTimestamp prop is set to true.
+	 * Get the total active drawing time in milliseconds.
 	 *
 	 * @remarks
-	 * This does not include the idle time when the user is not drawing. It only includes the time when the user is drawing on the canvas.
+	 * This only works when `withTimestamp` is enabled before drawing. Idle time
+	 * between strokes is not included.
+	 *
+	 * @returns Promise that resolves with the total sketching time.
 	 */
 	getSketchingTime: () => Promise<number>;
 	/**
-	 * Reset the canvas. This will remove all the paths drawn on the canvas and clear the Undo/Redo stack.
+	 * Remove all paths and clear undo/redo history.
 	 *
 	 * @remarks
-	 * If you only want to clear the paths drawn on the canvas, use the clearCanvas method.
+	 * Use `clearCanvas()` instead when the user should be able to undo the
+	 * clearing action.
+	 *
+	 * @returns Nothing.
 	 */
 	resetCanvas: () => void;
 }

--- a/packages/react-sketch-canvas/src/index.tsx
+++ b/packages/react-sketch-canvas/src/index.tsx
@@ -1,11 +1,20 @@
 export * from "./Canvas";
 export * from "./ReactSketchCanvas";
 export * from "./types";
+
+/**
+ * Low-level canvas props and ref types for consumers building custom state
+ * management around the SVG canvas.
+ */
 export type {
 	AllowOnlyPointerType,
 	CanvasProps,
 	CanvasRef,
 } from "./Canvas/types";
+
+/**
+ * Stateful sketch canvas props and ref types for the primary public component.
+ */
 export type {
 	ReactSketchCanvasProps,
 	ReactSketchCanvasRef,

--- a/packages/react-sketch-canvas/src/types/canvas.ts
+++ b/packages/react-sketch-canvas/src/types/canvas.ts
@@ -1,71 +1,115 @@
 /**
- * Image type to export the canvas as.
+ * Raster image format used by {@link ReactSketchCanvasRef.exportImage} and
+ * {@link CanvasRef.exportImage}.
+ *
+ * @remarks
+ * Use `"png"` when you need transparency. Use `"jpeg"` for smaller files or
+ * when the exported image should always include a solid background color.
+ *
+ * @public
  */
 export type ExportImageType = "jpeg" | "png";
 
 /**
- * Options for exporting the canvas as an image.
+ * Size options for raster image exports.
+ *
+ * @remarks
+ * When omitted, the exported image uses the rendered canvas element's current
+ * width and height. Provide both values to export a fixed-size image regardless
+ * of the on-screen canvas size.
+ *
+ * @public
  */
 export interface ExportImageOptions {
 	/**
-	 * Width of the exported image.
+	 * Width of the exported image in pixels.
+	 *
+	 * @defaultValue The current rendered canvas width.
 	 */
 	readonly width?: number;
 	/**
-	 * Height of the exported image.
+	 * Height of the exported image in pixels.
+	 *
+	 * @defaultValue The current rendered canvas height.
 	 */
 	readonly height?: number;
 }
 
 /**
- * Point on the canvas.
+ * A two-dimensional coordinate on the canvas.
  *
  * @remarks
- * The origin (0, 0) is the top-left corner of the canvas.
+ * Coordinates are measured in CSS pixels from the top-left corner of the
+ * rendered canvas. Pointer events, exported paths, and loaded paths all use
+ * this coordinate system.
+ *
+ * @public
  */
 export interface Point {
 	/**
-	 * The x coordinate of the point.
+	 * Horizontal coordinate in pixels from the left edge of the canvas.
 	 */
 	readonly x: number;
 	/**
-	 * The y coordinate of the point.
+	 * Vertical coordinate in pixels from the top edge of the canvas.
 	 */
 	readonly y: number;
 }
 
 /**
- * Path to draw on the canvas.
+ * A single stroke recorded by the sketch canvas.
+ *
+ * @remarks
+ * `CanvasPath` is the persistence format returned by
+ * {@link ReactSketchCanvasRef.exportPaths} and accepted by
+ * {@link ReactSketchCanvasRef.loadPaths}. Store this object if you want to save
+ * a drawing and replay it later.
+ *
+ * `drawMode` decides whether the stroke paints (`true`) or erases (`false`).
+ * Eraser strokes are stored as paths so exports and undo/redo can preserve the
+ * same visual result.
+ *
+ * @public
  */
 export interface CanvasPath {
 	/**
-	 * The paths to draw. Each path is an array of points.
+	 * Ordered points that make up this stroke.
+	 *
+	 * @remarks
+	 * A stroke can contain a single point, which is rendered as a dot.
 	 */
 	readonly paths: Point[];
 	/**
-	 * The stroke width of the path.
+	 * Stroke width in pixels.
 	 */
 	readonly strokeWidth: number;
 	/**
-	 * Color of the stroke.
+	 * Stroke color used when `drawMode` is `true`.
+	 *
+	 * @remarks
+	 * Eraser paths are stored with an internal mask color, but consumers usually
+	 * only need to preserve the value returned by `exportPaths`.
 	 */
 	readonly strokeColor: string;
 	/**
-	 * Whether the path is a draw mode or erase mode.
+	 * Whether the stroke draws color (`true`) or erases existing strokes
+	 * (`false`).
 	 */
 	readonly drawMode: boolean;
 	/**
-	 * The timestamp when the path was created. This is used to determine the order of the paths.
+	 * Timestamp captured when the stroke starts, in milliseconds since the Unix
+	 * epoch.
 	 *
 	 * @remarks
-	 * This will only be set when the withTimestamp option is set to true.
+	 * This is only present when `withTimestamp` is enabled.
 	 */
 	readonly startTimestamp?: number;
 	/**
-	 * The timestamp when the path was last updated. This is used to determine the order of the paths.
+	 * Timestamp captured when the stroke ends, in milliseconds since the Unix
+	 * epoch.
 	 *
 	 * @remarks
-	 * This will only be set when the withTimestamp option is set to true.
+	 * This is only present when `withTimestamp` is enabled.
 	 */
 	readonly endTimestamp?: number;
 }

--- a/packages/react-sketch-canvas/tests/unit/canvas/grouping.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/canvas/grouping.spec.ts
@@ -36,4 +36,8 @@ describe("canvas SVG grouping", () => {
 	it("keeps an initial empty group when the first stroke is an eraser", () => {
 		expect(getPathGroups([erase(1), draw(2)])).toEqual([[], [draw(2)]]);
 	});
+
+	it("does not create a trailing empty group after the last stroke is an eraser", () => {
+		expect(getPathGroups([draw(1), erase(2)])).toEqual([[draw(1)]]);
+	});
 });

--- a/packages/react-sketch-canvas/tests/unit/canvas/grouping.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/canvas/grouping.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+	getEraserPaths,
+	getPathGroups,
+} from "../../../src/Canvas/svg/grouping";
+import type { CanvasPath } from "../../../src/types";
+
+const draw = (id: number): CanvasPath => ({
+	drawMode: true,
+	strokeColor: `draw-${id}`,
+	strokeWidth: id,
+	paths: [{ x: id, y: id }],
+});
+
+const erase = (id: number): CanvasPath => ({
+	drawMode: false,
+	strokeColor: "#000000",
+	strokeWidth: id,
+	paths: [{ x: id, y: id }],
+});
+
+describe("canvas SVG grouping", () => {
+	it("returns only eraser paths", () => {
+		expect(getEraserPaths([draw(1), erase(2), draw(3), erase(4)])).toEqual([
+			erase(2),
+			erase(4),
+		]);
+	});
+
+	it("groups draw paths between eraser strokes", () => {
+		expect(
+			getPathGroups([draw(1), draw(2), erase(3), draw(4), erase(5)]),
+		).toEqual([[draw(1), draw(2)], [draw(4)]]);
+	});
+
+	it("keeps an initial empty group when the first stroke is an eraser", () => {
+		expect(getPathGroups([erase(1), draw(2)])).toEqual([[], [draw(2)]]);
+	});
+});

--- a/packages/react-sketch-canvas/tests/unit/canvas/pointer.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/canvas/pointer.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+	getCanvasPoint,
+	isAllowedPointerType,
+	isPenEraser,
+	shouldHandlePointerButton,
+} from "../../../src/Canvas/hooks/useCanvasPointerHandlers";
+
+describe("canvas pointer helpers", () => {
+	it("allows all pointer types when configured as all", () => {
+		expect(isAllowedPointerType("all", "mouse")).toBe(true);
+		expect(isAllowedPointerType("all", "pen")).toBe(true);
+		expect(isAllowedPointerType("all", "touch")).toBe(true);
+	});
+
+	it("rejects pointer types that do not match the configured type", () => {
+		expect(isAllowedPointerType("pen", "mouse")).toBe(false);
+		expect(isAllowedPointerType("pen", "pen")).toBe(true);
+	});
+
+	it("ignores non-primary mouse buttons", () => {
+		expect(shouldHandlePointerButton("mouse", 0)).toBe(true);
+		expect(shouldHandlePointerButton("mouse", 2)).toBe(false);
+		expect(shouldHandlePointerButton("pen", 5)).toBe(true);
+	});
+
+	it("detects pen eraser button bit", () => {
+		expect(isPenEraser("pen", 32)).toBe(true);
+		expect(isPenEraser("pen", 64)).toBe(false);
+		expect(isPenEraser("mouse", 32)).toBe(false);
+	});
+
+	it("converts page coordinates into canvas-relative coordinates", () => {
+		const point = getCanvasPoint(
+			{ pageX: 150, pageY: 220 },
+			{ left: 100, top: 200 },
+			{ scrollX: 10, scrollY: 20 },
+		);
+
+		expect(point).toEqual({ x: 40, y: 0 });
+	});
+});

--- a/packages/react-sketch-canvas/tests/unit/canvas/svgExport.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/canvas/svgExport.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { getCanvasWithViewBox } from "../../../src/Canvas/export/dom";
+import { prepareSvgForExport } from "../../../src/Canvas/export/svg";
+
+describe("canvas SVG export helpers", () => {
+	it("clones the svg and applies explicit width, height, and viewBox", () => {
+		const wrapper = document.createElement("div");
+		Object.defineProperties(wrapper, {
+			offsetWidth: { value: 320 },
+			offsetHeight: { value: 180 },
+		});
+		wrapper.innerHTML = `<svg id="sketch"></svg>`;
+
+		const result = getCanvasWithViewBox(wrapper);
+
+		expect(result.width).toBe(320);
+		expect(result.height).toBe(180);
+		expect(result.svgCanvas.getAttribute("viewBox")).toBe("0 0 320 180");
+		expect(result.svgCanvas.getAttribute("width")).toBe("320");
+		expect(result.svgCanvas.getAttribute("height")).toBe("180");
+	});
+
+	it("keeps the background image pattern when exporting with background image", () => {
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.innerHTML = `
+			<defs><pattern id="canvas__background"></pattern></defs>
+			<rect id="canvas__canvas-background" fill="url(#canvas__background)"></rect>
+		`;
+
+		prepareSvgForExport(svg, {
+			id: "canvas",
+			canvasColor: "white",
+			exportWithBackgroundImage: true,
+		});
+
+		expect(svg.querySelector("#canvas__background")).not.toBeNull();
+	});
+
+	it("removes the background image pattern and restores canvas color when exporting without background image", () => {
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.innerHTML = `
+			<defs><pattern id="canvas__background"></pattern></defs>
+			<rect id="canvas__canvas-background" fill="url(#canvas__background)"></rect>
+		`;
+
+		prepareSvgForExport(svg, {
+			id: "canvas",
+			canvasColor: "pink",
+			exportWithBackgroundImage: false,
+		});
+
+		expect(svg.querySelector("#canvas__background")).toBeNull();
+		expect(
+			svg.querySelector("#canvas__canvas-background")?.getAttribute("fill"),
+		).toBe("pink");
+	});
+});

--- a/packages/react-sketch-canvas/tests/unit/canvas/useCanvasExportHandle.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/canvas/useCanvasExportHandle.spec.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+import { useCanvasExportHandle } from "../../../src/Canvas/hooks/useCanvasExportHandle";
+import type { CanvasRef } from "../../../src/Canvas/types";
+
+function Harness({ canvasRef }: { canvasRef: React.RefObject<CanvasRef> }) {
+	const wrapperRef = React.useRef<HTMLDivElement>(null);
+
+	useCanvasExportHandle(canvasRef, {
+		canvasRef: wrapperRef,
+		id: "hook-canvas",
+		canvasColor: "white",
+		backgroundImage: "",
+		exportWithBackgroundImage: false,
+	});
+
+	return (
+		<div ref={wrapperRef}>
+			<svg id="hook-canvas" aria-hidden="true">
+				<rect id="hook-canvas__canvas-background" fill="white" />
+			</svg>
+		</div>
+	);
+}
+
+describe("useCanvasExportHandle", () => {
+	it("exposes exportSvg through the forwarded ref", async () => {
+		const canvasRef = React.createRef<CanvasRef>();
+
+		render(<Harness canvasRef={canvasRef} />);
+
+		await expect(canvasRef.current?.exportSvg()).resolves.toContain(
+			'id="hook-canvas"',
+		);
+	});
+});

--- a/packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx
@@ -1,0 +1,100 @@
+import { createEvent, fireEvent, render } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useCanvasPointerHandlers } from "../../../src/Canvas/hooks/useCanvasPointerHandlers";
+import type { AllowOnlyPointerType } from "../../../src/Canvas/types";
+import type { Point } from "../../../src/types";
+
+type HarnessProps = {
+	isDrawing?: boolean;
+	allowOnlyPointerType?: AllowOnlyPointerType;
+	onPointerDown?: (point: Point, isEraser?: boolean) => void;
+	onPointerMove?: (point: Point) => void;
+	onPointerUp?: () => void;
+};
+
+function Harness({
+	isDrawing = false,
+	allowOnlyPointerType = "all",
+	onPointerDown = vi.fn(),
+	onPointerMove = vi.fn(),
+	onPointerUp = vi.fn(),
+}: HarnessProps) {
+	const canvasRef = React.useRef<HTMLDivElement>(null);
+	const canvasSizeRef = React.useRef<{ width: number; height: number } | null>(
+		null,
+	);
+	const handlers = useCanvasPointerHandlers({
+		canvasRef,
+		canvasSizeRef,
+		isDrawing,
+		allowOnlyPointerType,
+		onPointerDown,
+		onPointerMove,
+		onPointerUp,
+	});
+
+	React.useEffect(() => {
+		if (!canvasRef.current) return;
+		canvasRef.current.getBoundingClientRect = () =>
+			({
+				left: 10,
+				top: 20,
+				width: 300,
+				height: 200,
+			}) as DOMRect;
+	}, []);
+
+	return (
+		<div
+			data-testid="canvas"
+			ref={canvasRef}
+			onPointerDown={handlers.handlePointerDown}
+			onPointerMove={handlers.handlePointerMove}
+			onPointerUp={handlers.handlePointerUp}
+		/>
+	);
+}
+
+describe("useCanvasPointerHandlers", () => {
+	it("normalizes pointer down into a canvas point", () => {
+		const onPointerDown = vi.fn();
+		const { getByTestId } = render(<Harness onPointerDown={onPointerDown} />);
+
+		const event = createEvent.pointerDown(getByTestId("canvas"), {
+			pointerType: "mouse",
+			button: 0,
+			buttons: 1,
+		});
+		Object.defineProperties(event, {
+			pageX: { value: 40 },
+			pageY: { value: 70 },
+		});
+
+		fireEvent(getByTestId("canvas"), event);
+
+		expect(onPointerDown).toHaveBeenCalledWith({ x: 30, y: 50 }, false);
+	});
+
+	it("does not move when drawing is false", () => {
+		const onPointerMove = vi.fn();
+		const { getByTestId } = render(<Harness onPointerMove={onPointerMove} />);
+
+		fireEvent.pointerMove(getByTestId("canvas"), {
+			pointerType: "mouse",
+			pageX: 40,
+			pageY: 70,
+		});
+
+		expect(onPointerMove).not.toHaveBeenCalled();
+	});
+
+	it("wires document pointerup", () => {
+		const onPointerUp = vi.fn();
+		render(<Harness onPointerUp={onPointerUp} />);
+
+		fireEvent.pointerUp(document, { pointerType: "mouse", button: 0 });
+
+		expect(onPointerUp).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx
@@ -89,6 +89,40 @@ describe("useCanvasPointerHandlers", () => {
 		expect(onPointerMove).not.toHaveBeenCalled();
 	});
 
+	it("ignores pointer down events from disallowed pointer types", () => {
+		const onPointerDown = vi.fn();
+		const { getByTestId } = render(
+			<Harness allowOnlyPointerType="pen" onPointerDown={onPointerDown} />,
+		);
+
+		fireEvent.pointerDown(getByTestId("canvas"), {
+			pointerType: "mouse",
+			button: 0,
+			buttons: 1,
+		});
+
+		expect(onPointerDown).not.toHaveBeenCalled();
+	});
+
+	it("normalizes pointer move while drawing", () => {
+		const onPointerMove = vi.fn();
+		const { getByTestId } = render(
+			<Harness isDrawing onPointerMove={onPointerMove} />,
+		);
+
+		const event = createEvent.pointerMove(getByTestId("canvas"), {
+			pointerType: "mouse",
+		});
+		Object.defineProperties(event, {
+			pageX: { value: 42 },
+			pageY: { value: 64 },
+		});
+
+		fireEvent(getByTestId("canvas"), event);
+
+		expect(onPointerMove).toHaveBeenCalledWith({ x: 32, y: 44 });
+	});
+
 	it("wires document pointerup", () => {
 		const onPointerUp = vi.fn();
 		render(<Harness onPointerUp={onPointerUp} />);

--- a/packages/react-sketch-canvas/tests/unit/paths/SvgPath.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/paths/SvgPath.spec.tsx
@@ -1,25 +1,6 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { SvgPath, bezierCommand, line } from "../../src/Paths";
-
-describe("Paths helpers", () => {
-	it("measures the length and angle between two points", () => {
-		const segment = line({ x: 0, y: 0 }, { x: 3, y: 4 });
-
-		expect(segment.length).toBe(5);
-		expect(segment.angle).toBeCloseTo(Math.atan2(4, 3));
-	});
-
-	it("builds a smooth cubic bezier command from neighboring points", () => {
-		const command = bezierCommand({ x: 10, y: 0 }, 1, [
-			{ x: 0, y: 0 },
-			{ x: 10, y: 0 },
-			{ x: 20, y: 10 },
-		]);
-
-		expect(command).toBe("C 2,0 5.999999999999999,-1.9999999999999998 10, 0");
-	});
-});
+import { SvgPath } from "../../../src/Paths/SvgPath";
 
 describe("SvgPath", () => {
 	it("renders a circle for a single-point stroke", () => {

--- a/packages/react-sketch-canvas/tests/unit/paths/geometry.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/paths/geometry.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { bezierCommand, line } from "../../../src/Paths/geometry";
+
+describe("Paths geometry", () => {
+	it("measures the length and angle between two points", () => {
+		const segment = line({ x: 0, y: 0 }, { x: 3, y: 4 });
+
+		expect(segment.length).toBe(5);
+		expect(segment.angle).toBeCloseTo(Math.atan2(4, 3));
+	});
+
+	it("builds a smooth cubic bezier command from neighboring points", () => {
+		const command = bezierCommand({ x: 10, y: 0 }, 1, [
+			{ x: 0, y: 0 },
+			{ x: 10, y: 0 },
+			{ x: 20, y: 10 },
+		]);
+
+		expect(command).toBe("C 2,0 5.999999999999999,-1.9999999999999998 10, 0");
+	});
+});

--- a/packages/react-sketch-canvas/tests/unit/paths/geometry.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/paths/geometry.spec.ts
@@ -16,6 +16,8 @@ describe("Paths geometry", () => {
 			{ x: 20, y: 10 },
 		]);
 
-		expect(command).toBe("C 2,0 5.999999999999999,-1.9999999999999998 10, 0");
+		expect(command.startsWith("C ")).toBe(true);
+		expect(command.endsWith(" 10, 0")).toBe(true);
+		expect(command).toMatch(/^C [^ ]+ [^ ]+ 10, 0$/);
 	});
 });

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/history.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/history.spec.ts
@@ -50,6 +50,20 @@ describe("history state", () => {
 		expect(redone.historyPos).toBe(2);
 	});
 
+	it("keeps state unchanged at undo and redo boundaries", () => {
+		const initial = createInitialSketchState();
+		expect(undoState(initial)).toBe(initial);
+
+		const atLatestHistory = {
+			...createInitialSketchState(),
+			history: [[], [path("red")]],
+			historyPos: 1,
+			currentPaths: [path("red")],
+			historySynced: true,
+		};
+		expect(redoState(atLatestHistory)).toBe(atLatestHistory);
+	});
+
 	it("clear appends an empty history entry", () => {
 		const state = {
 			...createInitialSketchState(),
@@ -72,6 +86,26 @@ describe("history state", () => {
 		);
 
 		expect(loaded.currentPaths).toEqual([path("red"), path("blue")]);
+	});
+
+	it("loadPaths drops redo history after the current position", () => {
+		const loaded = loadPathsState(
+			{
+				...createInitialSketchState(),
+				history: [[], [path("red")], [path("red"), path("green")]],
+				historyPos: 1,
+				historySynced: true,
+				currentPaths: [path("red")],
+			},
+			[path("blue")],
+		);
+
+		expect(loaded.history).toEqual([
+			[],
+			[path("red")],
+			[path("red"), path("blue")],
+		]);
+		expect(loaded.historyPos).toBe(2);
 	});
 
 	it("reset clears paths, history, and operation queue state", () => {

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/history.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/history.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+	addLastStrokeToHistory,
+	clearCanvasState,
+	createInitialSketchState,
+	loadPathsState,
+	redoState,
+	resetCanvasState,
+	undoState,
+} from "../../../src/ReactSketchCanvas/state/history";
+import type { CanvasPath } from "../../../src/types";
+
+const path = (strokeColor: string): CanvasPath => ({
+	drawMode: true,
+	strokeColor,
+	strokeWidth: 4,
+	paths: [{ x: 0, y: 0 }],
+});
+
+describe("history state", () => {
+	it("adds the current paths to history only when unsynced", () => {
+		const state = {
+			...createInitialSketchState(),
+			currentPaths: [path("red")],
+			historyPos: 1,
+			historySynced: false,
+		};
+
+		expect(addLastStrokeToHistory(state).history).toEqual([[], [path("red")]]);
+		expect(
+			addLastStrokeToHistory({ ...state, historySynced: true }).history,
+		).toEqual([[]]);
+	});
+
+	it("undoes and redoes through existing history", () => {
+		const state = {
+			...createInitialSketchState(),
+			history: [[], [path("red")], [path("red"), path("blue")]],
+			historyPos: 2,
+			currentPaths: [path("red"), path("blue")],
+			historySynced: true,
+		};
+
+		const undone = undoState(state);
+		expect(undone.currentPaths).toEqual([path("red")]);
+		expect(undone.historyPos).toBe(1);
+
+		const redone = redoState(undone);
+		expect(redone.currentPaths).toEqual([path("red"), path("blue")]);
+		expect(redone.historyPos).toBe(2);
+	});
+
+	it("clear appends an empty history entry", () => {
+		const state = {
+			...createInitialSketchState(),
+			currentPaths: [path("red")],
+			historyPos: 1,
+			historySynced: false,
+		};
+
+		const cleared = clearCanvasState(state);
+
+		expect(cleared.currentPaths).toEqual([]);
+		expect(cleared.history).toEqual([[], [path("red")], []]);
+		expect(cleared.historyPos).toBe(2);
+	});
+
+	it("loadPaths appends to current paths to preserve existing behavior", () => {
+		const loaded = loadPathsState(
+			{ ...createInitialSketchState(), currentPaths: [path("red")] },
+			[path("blue")],
+		);
+
+		expect(loaded.currentPaths).toEqual([path("red"), path("blue")]);
+	});
+
+	it("reset clears paths, history, and operation queue state", () => {
+		expect(resetCanvasState().history).toEqual([]);
+		expect(resetCanvasState().historyPos).toBe(0);
+		expect(resetCanvasState().currentPaths).toEqual([]);
+		expect(resetCanvasState().operationQueue).toEqual([]);
+	});
+});

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/operations.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/operations.spec.ts
@@ -30,6 +30,12 @@ describe("operations", () => {
 		expect(next.currentPaths).toEqual([path("red")]);
 	});
 
+	it("keeps state unchanged when loadPaths has no payload", () => {
+		const state = createInitialSketchState();
+
+		expect(applyOperation(state, { type: "loadPaths" })).toBe(state);
+	});
+
 	it("throws on unknown operations", () => {
 		expect(() =>
 			applyOperation(createInitialSketchState(), { type: "unknown" } as never),

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/operations.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/operations.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { createInitialSketchState } from "../../../src/ReactSketchCanvas/state/history";
+import {
+	applyOperation,
+	enqueueOperation,
+} from "../../../src/ReactSketchCanvas/state/operations";
+import type { CanvasPath } from "../../../src/types";
+
+const path = (strokeColor: string): CanvasPath => ({
+	drawMode: true,
+	strokeColor,
+	strokeWidth: 4,
+	paths: [{ x: 0, y: 0 }],
+});
+
+describe("operations", () => {
+	it("enqueues operations in order", () => {
+		expect(
+			enqueueOperation(createInitialSketchState(), { type: "clear" })
+				.operationQueue,
+		).toEqual([{ type: "clear" }]);
+	});
+
+	it("applies loadPaths operation", () => {
+		const next = applyOperation(createInitialSketchState(), {
+			type: "loadPaths",
+			payload: [path("red")],
+		});
+
+		expect(next.currentPaths).toEqual([path("red")]);
+	});
+
+	it("throws on unknown operations", () => {
+		expect(() =>
+			applyOperation(createInitialSketchState(), { type: "unknown" } as never),
+		).toThrow("Unknown operation type: unknown");
+	});
+});

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/sketchingTime.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/sketchingTime.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getSketchingTime } from "../../../src/ReactSketchCanvas/state/sketchingTime";
+
+describe("getSketchingTime", () => {
+	it("sums timestamp durations and treats missing timestamps as zero", () => {
+		expect(
+			getSketchingTime([
+				{
+					drawMode: true,
+					strokeColor: "red",
+					strokeWidth: 4,
+					paths: [{ x: 0, y: 0 }],
+					startTimestamp: 100,
+					endTimestamp: 250,
+				},
+				{
+					drawMode: true,
+					strokeColor: "blue",
+					strokeWidth: 4,
+					paths: [{ x: 1, y: 1 }],
+				},
+			]),
+		).toBe(150);
+	});
+});

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/strokes.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/strokes.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+	appendPointToLastStroke,
+	createStroke,
+	finishStroke,
+} from "../../../src/ReactSketchCanvas/state/strokes";
+
+describe("stroke state helpers", () => {
+	it("creates a draw stroke", () => {
+		expect(
+			createStroke({
+				point: { x: 1, y: 2 },
+				drawMode: true,
+				strokeColor: "red",
+				strokeWidth: 4,
+				eraserWidth: 8,
+				withTimestamp: false,
+				now: 100,
+			}),
+		).toEqual({
+			drawMode: true,
+			strokeColor: "red",
+			strokeWidth: 4,
+			paths: [{ x: 1, y: 2 }],
+		});
+	});
+
+	it("creates an eraser stroke when draw mode is false", () => {
+		expect(
+			createStroke({
+				point: { x: 1, y: 2 },
+				drawMode: false,
+				strokeColor: "red",
+				strokeWidth: 4,
+				eraserWidth: 8,
+				withTimestamp: true,
+				now: 100,
+			}),
+		).toEqual({
+			drawMode: false,
+			strokeColor: "#000000",
+			strokeWidth: 8,
+			paths: [{ x: 1, y: 2 }],
+			startTimestamp: 100,
+			endTimestamp: 0,
+		});
+	});
+
+	it("appends a point to the last stroke", () => {
+		const paths = [
+			createStroke({
+				point: { x: 1, y: 2 },
+				drawMode: true,
+				strokeColor: "red",
+				strokeWidth: 4,
+				eraserWidth: 8,
+				withTimestamp: false,
+				now: 100,
+			}),
+		];
+
+		expect(appendPointToLastStroke(paths, { x: 3, y: 4 })[0].paths).toEqual([
+			{ x: 1, y: 2 },
+			{ x: 3, y: 4 },
+		]);
+	});
+
+	it("finishes timestamped last stroke", () => {
+		const paths = [
+			createStroke({
+				point: { x: 1, y: 2 },
+				drawMode: true,
+				strokeColor: "red",
+				strokeWidth: 4,
+				eraserWidth: 8,
+				withTimestamp: true,
+				now: 100,
+			}),
+		];
+
+		expect(finishStroke(paths, true, 250)[0].endTimestamp).toBe(250);
+		expect(finishStroke(paths, false, 250)[0].endTimestamp).toBe(0);
+	});
+});

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/strokes.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/strokes.spec.ts
@@ -65,6 +65,12 @@ describe("stroke state helpers", () => {
 		]);
 	});
 
+	it("keeps an empty path list unchanged when appending a point", () => {
+		const paths = [] as ReturnType<typeof createStroke>[];
+
+		expect(appendPointToLastStroke(paths, { x: 3, y: 4 })).toBe(paths);
+	});
+
 	it("finishes timestamped last stroke", () => {
 		const paths = [
 			createStroke({
@@ -80,5 +86,11 @@ describe("stroke state helpers", () => {
 
 		expect(finishStroke(paths, true, 250)[0].endTimestamp).toBe(250);
 		expect(finishStroke(paths, false, 250)[0].endTimestamp).toBe(0);
+	});
+
+	it("keeps an empty path list unchanged when finishing a stroke", () => {
+		const paths = [] as ReturnType<typeof createStroke>[];
+
+		expect(finishStroke(paths, true, 250)).toBe(paths);
 	});
 });

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasController.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasController.spec.tsx
@@ -1,0 +1,83 @@
+import { act, render } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useSketchCanvasController } from "../../../src/ReactSketchCanvas/hooks/useSketchCanvasController";
+import type { CanvasPath, Point } from "../../../src/types";
+
+type ControllerSnapshot = ReturnType<typeof useSketchCanvasController>;
+
+function Harness({
+	onReady,
+	onChange = vi.fn(),
+	onStroke = vi.fn(),
+}: {
+	onReady: (controller: ControllerSnapshot) => void;
+	onChange?: (paths: CanvasPath[]) => void;
+	onStroke?: (path: CanvasPath, isEraser: boolean) => void;
+}) {
+	const controller = useSketchCanvasController({
+		strokeColor: "red",
+		strokeWidth: 4,
+		eraserWidth: 8,
+		withTimestamp: false,
+		onChange,
+		onStroke,
+	});
+
+	React.useEffect(() => {
+		onReady(controller);
+	}, [controller, onReady]);
+
+	return null;
+}
+
+describe("useSketchCanvasController", () => {
+	it("creates and extends a stroke from pointer events", () => {
+		let controller: ControllerSnapshot | undefined;
+		const onReady = vi.fn((next: ControllerSnapshot) => {
+			controller = next;
+		});
+
+		render(<Harness onReady={onReady} />);
+
+		act(() => {
+			controller?.handlePointerDown({ x: 1, y: 2 } satisfies Point);
+		});
+		act(() => {
+			controller?.handlePointerMove({ x: 3, y: 4 } satisfies Point);
+		});
+
+		expect(controller?.currentPaths).toEqual([
+			{
+				drawMode: true,
+				strokeColor: "red",
+				strokeWidth: 4,
+				paths: [
+					{ x: 1, y: 2 },
+					{ x: 3, y: 4 },
+				],
+			},
+		]);
+	});
+
+	it("uses eraser stroke settings for eraser input", () => {
+		let controller: ControllerSnapshot | undefined;
+		render(
+			<Harness
+				onReady={(next) => {
+					controller = next;
+				}}
+			/>,
+		);
+
+		act(() => {
+			controller?.handlePointerDown({ x: 1, y: 2 }, true);
+		});
+
+		expect(controller?.currentPaths[0]).toMatchObject({
+			drawMode: false,
+			strokeColor: "#000000",
+			strokeWidth: 8,
+		});
+	});
+});

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasImperativeHandle.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasImperativeHandle.spec.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { CanvasRef } from "../../../src/Canvas/types";
 import { useSketchCanvasImperativeHandle } from "../../../src/ReactSketchCanvas/hooks/useSketchCanvasImperativeHandle";
+import type { Operation } from "../../../src/ReactSketchCanvas/state/operations";
 import type { ReactSketchCanvasRef } from "../../../src/ReactSketchCanvas/types";
 import type { CanvasPath } from "../../../src/types";
 
@@ -23,18 +24,28 @@ const canvasApi: CanvasRef = {
 function Harness({
 	forwardedRef,
 	withTimestamp = true,
+	canvasRefOverride,
+	enqueueOperation = vi.fn(),
+	resetCanvas = vi.fn(),
+	setEraseMode = vi.fn(),
 }: {
 	forwardedRef: React.RefObject<ReactSketchCanvasRef>;
 	withTimestamp?: boolean;
+	canvasRefOverride?: CanvasRef | null;
+	enqueueOperation?: (operation: Operation) => void;
+	resetCanvas?: () => void;
+	setEraseMode?: (erase: boolean) => void;
 }) {
-	const canvasRef = React.useRef<CanvasRef>(canvasApi);
+	const canvasRef = React.useRef<CanvasRef | null>(
+		canvasRefOverride === undefined ? canvasApi : canvasRefOverride,
+	);
 	useSketchCanvasImperativeHandle(forwardedRef, {
 		canvasRef,
 		currentPaths: [path],
 		withTimestamp,
-		setEraseMode: vi.fn(),
-		enqueueOperation: vi.fn(),
-		resetCanvas: vi.fn(),
+		setEraseMode,
+		enqueueOperation,
+		resetCanvas,
 	});
 	return null;
 }
@@ -59,5 +70,49 @@ describe("useSketchCanvasImperativeHandle", () => {
 		await expect(ref.current?.getSketchingTime()).rejects.toThrow(
 			"Set 'withTimestamp' prop to get sketching time",
 		);
+	});
+
+	it("throws export errors when the low-level canvas ref is not ready", async () => {
+		const ref = React.createRef<ReactSketchCanvasRef>();
+		render(<Harness forwardedRef={ref} canvasRefOverride={null} />);
+
+		expect(() => ref.current?.exportImage("png")).toThrow(
+			"Export function called before canvas loaded",
+		);
+		await expect(ref.current?.exportSvg()).rejects.toThrow(
+			"Export function called before canvas loaded",
+		);
+	});
+
+	it("maps imperative state methods to controller operations", () => {
+		const ref = React.createRef<ReactSketchCanvasRef>();
+		const enqueueOperation = vi.fn();
+		const resetCanvas = vi.fn();
+		const setEraseMode = vi.fn();
+		render(
+			<Harness
+				forwardedRef={ref}
+				enqueueOperation={enqueueOperation}
+				resetCanvas={resetCanvas}
+				setEraseMode={setEraseMode}
+			/>,
+		);
+
+		ref.current?.eraseMode(true);
+		ref.current?.clearCanvas();
+		ref.current?.undo();
+		ref.current?.redo();
+		ref.current?.loadPaths([path]);
+		ref.current?.resetCanvas();
+
+		expect(setEraseMode).toHaveBeenCalledWith(true);
+		expect(enqueueOperation).toHaveBeenNthCalledWith(1, { type: "clear" });
+		expect(enqueueOperation).toHaveBeenNthCalledWith(2, { type: "undo" });
+		expect(enqueueOperation).toHaveBeenNthCalledWith(3, { type: "redo" });
+		expect(enqueueOperation).toHaveBeenNthCalledWith(4, {
+			type: "loadPaths",
+			payload: [path],
+		});
+		expect(resetCanvas).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasImperativeHandle.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasImperativeHandle.spec.tsx
@@ -1,0 +1,63 @@
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { CanvasRef } from "../../../src/Canvas/types";
+import { useSketchCanvasImperativeHandle } from "../../../src/ReactSketchCanvas/hooks/useSketchCanvasImperativeHandle";
+import type { ReactSketchCanvasRef } from "../../../src/ReactSketchCanvas/types";
+import type { CanvasPath } from "../../../src/types";
+
+const path: CanvasPath = {
+	drawMode: true,
+	strokeColor: "red",
+	strokeWidth: 4,
+	paths: [{ x: 0, y: 0 }],
+	startTimestamp: 10,
+	endTimestamp: 30,
+};
+
+const canvasApi: CanvasRef = {
+	exportImage: vi.fn(async () => "data:image/png;base64,abc"),
+	exportSvg: vi.fn(async () => "<svg></svg>"),
+};
+
+function Harness({
+	forwardedRef,
+	withTimestamp = true,
+}: {
+	forwardedRef: React.RefObject<ReactSketchCanvasRef>;
+	withTimestamp?: boolean;
+}) {
+	const canvasRef = React.useRef<CanvasRef>(canvasApi);
+	useSketchCanvasImperativeHandle(forwardedRef, {
+		canvasRef,
+		currentPaths: [path],
+		withTimestamp,
+		setEraseMode: vi.fn(),
+		enqueueOperation: vi.fn(),
+		resetCanvas: vi.fn(),
+	});
+	return null;
+}
+
+describe("useSketchCanvasImperativeHandle", () => {
+	it("exposes export methods and current paths", async () => {
+		const ref = React.createRef<ReactSketchCanvasRef>();
+		render(<Harness forwardedRef={ref} />);
+
+		await expect(ref.current?.exportImage("png")).resolves.toBe(
+			"data:image/png;base64,abc",
+		);
+		await expect(ref.current?.exportSvg()).resolves.toBe("<svg></svg>");
+		await expect(ref.current?.exportPaths()).resolves.toEqual([path]);
+		await expect(ref.current?.getSketchingTime()).resolves.toBe(20);
+	});
+
+	it("rejects sketching time when timestamps are disabled", async () => {
+		const ref = React.createRef<ReactSketchCanvasRef>();
+		render(<Harness forwardedRef={ref} withTimestamp={false} />);
+
+		await expect(ref.current?.getSketchingTime()).rejects.toThrow(
+			"Set 'withTimestamp' prop to get sketching time",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- Split the React Sketch Canvas package implementation into focused rendering, export, pointer, state, and controller modules.
- Added focused unit tests for extracted helpers, hooks, state transitions, and critical edge cases.
- Added user-facing TSDoc for public package APIs and developer-facing docs for internal extracted logic.

## Validation

- pnpm --filter react-sketch-canvas format
- pnpm --filter react-sketch-canvas lint
- pnpm --filter react-sketch-canvas build
- pnpm --filter react-sketch-canvas test:unit
- pnpm --filter react-sketch-canvas test:ct
- pnpm --filter react-sketch-canvas test:e2e
