### PR TITLE
fix: improve Firefox SVG mask compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
-        run: pnpm --filter react-sketch-canvas exec playwright install chromium
+        run: pnpm --filter react-sketch-canvas exec playwright install --with-deps chromium firefox
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, "release-*"]
   pull_request:
-    branches: [main]
+    branches: [main, "release-*"]
 
 jobs:
   build:

--- a/packages/react-sketch-canvas/playwright-ct.config.ts
+++ b/packages/react-sketch-canvas/playwright-ct.config.ts
@@ -20,5 +20,9 @@ export default defineConfig({
 			name: "chromium",
 			use: { ...devices["Desktop Chrome"] },
 		},
+		{
+			name: "firefox",
+			use: { ...devices["Desktop Firefox"] },
+		},
 	],
 });

--- a/packages/react-sketch-canvas/playwright-e2e.config.ts
+++ b/packages/react-sketch-canvas/playwright-e2e.config.ts
@@ -12,8 +12,17 @@ export default defineConfig({
 	use: {
 		baseURL: "http://127.0.0.1:3200",
 		trace: "on-first-retry",
-		...devices["Desktop Chrome"],
 	},
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+		{
+			name: "firefox",
+			use: { ...devices["Desktop Firefox"] },
+		},
+	],
 	webServer: {
 		command: "pnpm exec vite playwright/e2e --host 127.0.0.1 --port 3200",
 		url: "http://127.0.0.1:3200",

--- a/packages/react-sketch-canvas/playwright/e2e/canvas.spec.ts
+++ b/packages/react-sketch-canvas/playwright/e2e/canvas.spec.ts
@@ -1,5 +1,62 @@
-import { expect, test } from "playwright/test";
+import { type Page, expect, test } from "playwright/test";
 import { drawLine } from "../../tests/commands";
+
+async function getSvgPixel(page: Page, selector: string, x: number, y: number) {
+	return page.evaluate(
+		async ({ selector, x, y }) => {
+			const svg = document.querySelector(selector);
+
+			if (!(svg instanceof SVGSVGElement)) {
+				throw new Error(`SVG not found for selector: ${selector}`);
+			}
+
+			const image = new Image();
+			const svgClone = svg.cloneNode(true) as SVGSVGElement;
+			const width = svg.clientWidth;
+			const height = svg.clientHeight;
+
+			svgClone.setAttribute("width", width.toString());
+			svgClone.setAttribute("height", height.toString());
+			svgClone.setAttribute("viewBox", `0 0 ${width} ${height}`);
+
+			const svgText = new XMLSerializer().serializeToString(svgClone);
+			const url = URL.createObjectURL(
+				new Blob([svgText], { type: "image/svg+xml" }),
+			);
+
+			try {
+				await new Promise<void>((resolve, reject) => {
+					image.addEventListener("load", () => resolve(), { once: true });
+					image.addEventListener(
+						"error",
+						() => reject(new Error("SVG load failed")),
+						{
+							once: true,
+						},
+					);
+					image.src = url;
+				});
+
+				const canvas = document.createElement("canvas");
+				canvas.width = width;
+				canvas.height = height;
+
+				const context = canvas.getContext("2d");
+
+				if (!context) {
+					throw new Error("2D canvas context unavailable");
+				}
+
+				context.drawImage(image, 0, 0);
+
+				return Array.from(context.getImageData(x, y, 1, 1).data);
+			} finally {
+				URL.revokeObjectURL(url);
+			}
+		},
+		{ selector, x, y },
+	);
+}
 
 test("draws, exports, and clears on the browser harness", async ({ page }) => {
 	await page.goto("/");
@@ -20,6 +77,24 @@ test("draws, exports, and clears on the browser harness", async ({ page }) => {
 	await page.locator("#clear-button").click();
 	await expect(page.locator("#path-count")).toHaveText("0");
 	await expect(canvas.locator("path")).toHaveCount(0);
+});
+
+test("renders pen strokes outside the upper-left quadrant in Firefox", async ({
+	page,
+}) => {
+	await page.goto("/");
+
+	const canvas = page.locator("#rsc");
+	await drawLine(canvas, { length: 60, originX: 300, originY: 220 });
+
+	await expect(canvas.locator("path")).toHaveCount(1);
+
+	const strokePixel = await getSvgPixel(page, "#rsc", 330, 250);
+
+	expect(strokePixel[0]).toBeGreaterThan(200);
+	expect(strokePixel[1]).toBeLessThan(80);
+	expect(strokePixel[2]).toBeLessThan(80);
+	expect(strokePixel[3]).toBe(255);
 });
 
 test("supports eraser mode with undo and redo controls", async ({ page }) => {
@@ -44,4 +119,22 @@ test("supports eraser mode with undo and redo controls", async ({ page }) => {
 
 	await page.locator("#export-svg-button").click();
 	await expect(page.locator("#exported-svg")).toContainText("rsc__eraser-0");
+	await expect(page.locator("#exported-svg")).not.toContainText("undefined");
+});
+
+test("renders erased pixels as canvas background in Firefox-compatible SVG masks", async ({
+	page,
+}) => {
+	await page.goto("/");
+
+	const canvas = page.locator("#rsc");
+	await drawLine(canvas, { length: 80, originX: 20, originY: 20 });
+	await page.locator("#eraser-button").click();
+	await drawLine(canvas, { length: 30, originX: 20, originY: 20 });
+
+	await expect(canvas.locator("#rsc__eraser-stroke-group path")).toHaveCount(1);
+
+	const erasedPixel = await getSvgPixel(page, "#rsc", 30, 30);
+
+	expect(erasedPixel).toEqual([255, 255, 255, 255]);
 });

--- a/packages/react-sketch-canvas/src/Canvas/svg/CanvasSvg.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/CanvasSvg.tsx
@@ -52,8 +52,8 @@ export function CanvasSvg({
 			id={id}
 			viewBox={viewBox}
 		>
-			<HiddenEraserStrokes id={id} eraserPaths={eraserPaths} />
 			<defs>
+				<HiddenEraserStrokes id={id} eraserPaths={eraserPaths} />
 				<BackgroundPattern
 					id={id}
 					backgroundImage={backgroundImage}

--- a/packages/react-sketch-canvas/src/Canvas/svg/CanvasSvg.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/CanvasSvg.tsx
@@ -1,4 +1,3 @@
-import type { CanvasPath } from "../../types";
 import type { CanvasProps } from "../types";
 import { BackgroundPattern, BackgroundRect } from "./Background";
 import { EraserMaskDefs, HiddenEraserStrokes } from "./EraserMasks";

--- a/packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx
@@ -19,7 +19,7 @@ export function HiddenEraserStrokes({
 	eraserPaths,
 }: EraserMasksProps): JSX.Element {
 	return (
-		<g id={`${id}__eraser-stroke-group`} display="none">
+		<g id={`${id}__eraser-stroke-group`}>
 			<rect
 				id={`${id}__mask-background`}
 				x="0"

--- a/packages/react-sketch-canvas/tests/actions/erase.spec.tsx
+++ b/packages/react-sketch-canvas/tests/actions/erase.spec.tsx
@@ -221,4 +221,28 @@ test.describe("eraser", () => {
 			canvas.locator(firstStrokeGroupId).locator("path"),
 		).toHaveCount(1);
 	});
+
+	test("should keep eraser mask source paths in defs for Firefox rendering", async ({
+		mount,
+	}) => {
+		const canvasId = "rsc";
+		const eraserButtonId = "eraser-button";
+
+		const component = await mount(
+			<WithEraserButton id={canvasId} eraserButtonId={eraserButtonId} />,
+		);
+
+		const canvas = component.locator(`#${canvasId}`);
+
+		await drawLine(canvas, { length: 50, originX: 0, originY: 10 });
+		await component.locator(`#${eraserButtonId}`).click();
+		await drawLine(canvas, { length: 10, originX: 0, originY: 10 });
+
+		const eraserStrokeGroup = canvas.locator(
+			`defs > #${canvasId}__eraser-stroke-group`,
+		);
+
+		await expect(eraserStrokeGroup.locator("path")).toHaveCount(1);
+		await expect(eraserStrokeGroup).not.toHaveAttribute("display", "none");
+	});
 });

--- a/packages/react-sketch-canvas/tests/stories/WithSizedExportButton.story.tsx
+++ b/packages/react-sketch-canvas/tests/stories/WithSizedExportButton.story.tsx
@@ -1,8 +1,5 @@
 import { useRef, useState } from "react";
-import {
-	ReactSketchCanvas,
-	type ReactSketchCanvasRef,
-} from "../../src/ReactSketchCanvas";
+import { ReactSketchCanvas, type ReactSketchCanvasRef } from "../../src";
 
 export function WithSizedExportButton() {
 	const canvasRef = useRef<ReactSketchCanvasRef>(null);


### PR DESCRIPTION
## Summary
- add Firefox projects to Playwright CT and E2E configs
- install Firefox in CI before Playwright tests run
- move SVG eraser mask sources into `<defs>` so Firefox can resolve masks reliably
- add Firefox regressions for pen visibility outside the upper-left quadrant, eraser rendering, and `undefined` mask output

## Root Cause
Firefox is stricter than Chromium about invalid or non-renderable SVG mask references. The renderer already avoided missing mask references, but reusable eraser mask source paths still lived in a hidden SVG subtree; Firefox can fail to use those as mask sources. CI also only installed Chromium, so Firefox Playwright projects would not be exercised there.

## Issues
Fixes #194
Addresses #54
Addresses #141

## Validation
- `pnpm --dir packages/react-sketch-canvas test:unit`
- `pnpm --dir packages/react-sketch-canvas exec playwright test -c playwright-e2e.config.ts`
- `pnpm --dir packages/react-sketch-canvas exec playwright test -c playwright-ct.config.ts`
- `pnpm --dir packages/react-sketch-canvas lint`
- `pnpm --dir packages/react-sketch-canvas build`
