### PR TITLE
Fix image export background handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [main, "release-*"]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     name: Build, lint, and test on Node ${{ matrix.node }} and ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+          cache: pnpm
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
@@ -29,8 +30,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright system dependencies
+        run: pnpm --filter react-sketch-canvas exec playwright install-deps chromium firefox
+
       - name: Install Playwright browsers
-        run: pnpm --filter react-sketch-canvas exec playwright install --with-deps chromium firefox
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter react-sketch-canvas exec playwright install chromium firefox
 
       - name: Lint
         run: pnpm lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Repository Instructions
+
+## Git And Workflow
+
+- Always use conventional commits.
+- If the branch name, spec, or ticket context includes a Linear ticket, include it in the pull request description.
+- Do not change public APIs without discussing the change first. If a bug exposes a public API limitation, explain the tradeoff before changing the API.
+- Keep changes scoped to the requested work. Do not revert or rewrite unrelated user changes in the working tree.
+
+## Code Quality Expectations
+
+- Prefer small, focused modules over large files that mix rendering, state, export, pointer handling, and utility logic.
+- Extract logic into unit-testable functions or hooks when it improves readability and test coverage.
+- Follow the existing package architecture and naming patterns before introducing new abstractions.
+- Compose types from existing public or internal types with `Pick`, `Omit`, `Partial`, `Required`, or local aliases when that avoids repeating the same shape.
+- Avoid duplicating prop shapes across components and hooks. Derive internal props from the public props where practical.
+- Keep console warnings and thrown errors user friendly. Messages should explain what went wrong and what the consumer can check or change.
+
+## TypeScript Naming
+
+- Use `Params` as the suffix for object types that represent function arguments.
+- Use `Returns` as the suffix for function return types.
+- Example: `exportImageFromSvg` should accept `ExportImageFromSvgParams` and return `ExportImageFromSvgReturns`.
+- Type React components and forwarded refs explicitly so generated declarations expose clear prop and ref contracts.
+- Keep public prop types stable and readable for package consumers.
+
+## Documentation
+
+- Add TSDoc for all public code exported by the React Sketch Canvas package.
+- Public TSDoc is compiled into documentation and should be written as user-facing documentation, not implementation notes.
+- Public props, refs, return values, defaults, side effects, and usage constraints should be documented thoroughly.
+- Add developer-facing comments or TSDoc for internal extracted logic when it clarifies non-obvious state transitions, SVG rendering behavior, export behavior, pointer handling, or browser constraints.
+- Do not add comments that merely restate obvious code.
+
+## Testing Expectations
+
+- Add or update unit tests when extracting logic into testable functions or hooks.
+- Use Testing Library for React hooks and component-facing behavior.
+- Cover critical paths and edge cases without creating excessive tests.
+- Prefer deterministic assertions. Avoid exact floating-point string assertions; assert stable structure, rounded values, or use approximate numeric checks where appropriate.
+- Critical extracted logic should have focused coverage for:
+  - pointer filtering, pointer normalization, and document-level pointer release;
+  - SVG grouping, eraser masks, and export preparation;
+  - image export error paths and background handling;
+  - sketch state history, undo/redo boundaries, reset, clear, and loaded paths;
+  - imperative ref methods and hook contracts.
+- Run the relevant package verification before claiming work is complete. For broad package changes, prefer:
+  - `pnpm --filter react-sketch-canvas format`
+  - `pnpm --filter react-sketch-canvas lint`
+  - `pnpm --filter react-sketch-canvas build`
+  - `pnpm --filter react-sketch-canvas test:unit`
+  - `pnpm --filter react-sketch-canvas test:ct`
+  - `pnpm --filter react-sketch-canvas test:e2e`

--- a/docs/app/lib/site-paths.ts
+++ b/docs/app/lib/site-paths.ts
@@ -1,7 +1,11 @@
-export const docsBasePath = "/react-sketch-canvas";
+export const docsBasePath = import.meta.env.PROD ? "/react-sketch-canvas" : "";
 
 export function withDocsBasePath(path: string) {
 	if (!path.startsWith("/")) {
+		return path;
+	}
+
+	if (docsBasePath === "") {
 		return path;
 	}
 

--- a/docs/app/root.tsx
+++ b/docs/app/root.tsx
@@ -1,6 +1,7 @@
 import { RootProvider } from "fumadocs-ui/provider/react-router";
 import type { LinksFunction } from "react-router";
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
+import { withDocsBasePath } from "~/lib/site-paths";
 import stylesheet from "./styles.css?url";
 
 export const links: LinksFunction = () => [
@@ -20,7 +21,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
 				<RootProvider
 					search={{
 						options: {
-							api: "/react-sketch-canvas/api/search",
+							api: withDocsBasePath("/api/search"),
 						},
 					}}
 				>

--- a/docs/react-router.config.ts
+++ b/docs/react-router.config.ts
@@ -42,6 +42,7 @@ function getDocPaths() {
 }
 
 export default {
-	basename: "/react-sketch-canvas",
+	basename:
+		process.env.NODE_ENV === "production" ? "/react-sketch-canvas" : "/",
 	prerender: [...getDocPaths(), "/llms.txt", "/llms-full.txt"],
 } satisfies Config;

--- a/docs/src/components/HomePageHero.tsx
+++ b/docs/src/components/HomePageHero.tsx
@@ -1,4 +1,5 @@
 import { IconArrowRight, IconBrandGithub } from "@tabler/icons-react";
+import { withDocsBasePath } from "../../app/lib/site-paths";
 import logo from "../assets/logo.svg";
 
 const githubUrl = "https://github.com/vinothpandian/react-sketch-canvas";
@@ -19,7 +20,7 @@ export function HomePageHero() {
 					<div className="mt-7 flex flex-wrap items-center justify-center gap-3 md:justify-start">
 						<a
 							className="inline-flex h-10 items-center gap-2 rounded-md bg-fd-primary px-4 text-sm font-medium text-fd-primary-foreground transition-colors hover:bg-fd-primary/90"
-							href="/react-sketch-canvas/installation/"
+							href={withDocsBasePath("/installation/")}
 						>
 							<span>Get started</span>
 							<IconArrowRight aria-hidden="true" size={18} stroke={2.4} />

--- a/docs/src/content/docs/examples/background/export.mdx
+++ b/docs/src/content/docs/examples/background/export.mdx
@@ -1,0 +1,16 @@
+---
+title: Export with background
+description: Export raster images with the configured canvas background.
+---
+
+import ExampleBlock from "../../../../components/ExampleBlock";
+import BackgroundExport from "../../../../examples/BackgroundExport";
+import BackgroundExportSource from "../../../../examples/BackgroundExport.tsx?raw";
+
+Raster exports can include the configured `backgroundImage` when `exportWithBackgroundImage` is enabled. Use this when consumers need a PNG or JPEG that combines the drawing strokes with the same background image shown in the canvas.
+
+If the browser cannot load a remote background image during export, the drawing can still export without that background layer.
+
+<ExampleBlock source={BackgroundExportSource}>
+  <BackgroundExport />
+</ExampleBlock>

--- a/docs/src/content/docs/examples/background/meta.json
+++ b/docs/src/content/docs/examples/background/meta.json
@@ -1,4 +1,4 @@
 {
 	"title": "Background",
-	"pages": ["image", "data-uri"]
+	"pages": ["image", "data-uri", "export"]
 }

--- a/docs/src/examples/BackgroundExport.tsx
+++ b/docs/src/examples/BackgroundExport.tsx
@@ -1,0 +1,237 @@
+import { type ChangeEvent, useEffect, useRef, useState } from "react";
+import {
+	type CanvasPath,
+	ReactSketchCanvas,
+	type ReactSketchCanvasRef,
+} from "react-sketch-canvas";
+
+const backgroundSources = {
+	remote:
+		"https://images.pexels.com/photos/1193743/pexels-photo-1193743.jpeg?cs=srgb&fm=jpg",
+	dataUri:
+		"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 360'%3E%3Crect width='640' height='360' fill='%23f8fafc'/%3E%3Cpath d='M0 260 C120 170 220 310 340 220 S540 160 640 230 V360 H0 Z' fill='%23bfdbfe'/%3E%3Ccircle cx='500' cy='95' r='54' fill='%23facc15'/%3E%3Cpath d='M60 110 H300' stroke='%2314b8a6' stroke-width='20' stroke-linecap='round'/%3E%3Cpath d='M60 150 H230' stroke='%23fb7185' stroke-width='20' stroke-linecap='round'/%3E%3C/svg%3E",
+	inaccessible: "https://example.invalid/react-sketch-canvas-background.png",
+} as const;
+
+const initialPaths: CanvasPath[] = [
+	{
+		drawMode: true,
+		strokeColor: "#dc2626",
+		strokeWidth: 5,
+		paths: [
+			{ x: 80, y: 80 },
+			{ x: 140, y: 130 },
+			{ x: 210, y: 95 },
+			{ x: 280, y: 150 },
+		],
+	},
+	{
+		drawMode: true,
+		strokeColor: "#2563eb",
+		strokeWidth: 8,
+		paths: [
+			{ x: 360, y: 95 },
+			{ x: 420, y: 145 },
+			{ x: 500, y: 105 },
+			{ x: 560, y: 155 },
+		],
+	},
+];
+
+type BackgroundSource = keyof typeof backgroundSources;
+type ExportFormat = "png" | "jpeg" | "svg";
+type ExportResult =
+	| { format: "png" | "jpeg"; value: string }
+	| { format: "svg"; value: string };
+
+export default function App() {
+	const canvasRef = useRef<ReactSketchCanvasRef>(null);
+	const [backgroundSource, setBackgroundSource] =
+		useState<BackgroundSource>("dataUri");
+	const [exportFormat, setExportFormat] = useState<ExportFormat>("png");
+	const [exportWithBackgroundImage, setExportWithBackgroundImage] =
+		useState(true);
+	const [useFixedSize, setUseFixedSize] = useState(false);
+	const [exportResult, setExportResult] = useState<ExportResult | null>(null);
+
+	useEffect(() => {
+		canvasRef.current?.resetCanvas();
+		canvasRef.current?.loadPaths(initialPaths);
+	}, []);
+
+	const handleBackgroundSourceChange = (
+		event: ChangeEvent<HTMLSelectElement>,
+	) => {
+		setBackgroundSource(event.target.value as BackgroundSource);
+		setExportResult(null);
+	};
+
+	const handleExportFormatChange = (event: ChangeEvent<HTMLSelectElement>) => {
+		setExportFormat(event.target.value as ExportFormat);
+		setExportResult(null);
+	};
+
+	const handleExportWithBackgroundChange = (
+		event: ChangeEvent<HTMLInputElement>,
+	) => {
+		setExportWithBackgroundImage(event.target.checked);
+		setExportResult(null);
+	};
+
+	const handleFixedSizeChange = (event: ChangeEvent<HTMLInputElement>) => {
+		setUseFixedSize(event.target.checked);
+		setExportResult(null);
+	};
+
+	const handleExportClick = async () => {
+		if (!canvasRef.current) return;
+
+		if (exportFormat === "svg") {
+			const svg = await canvasRef.current.exportSvg();
+			setExportResult({ format: "svg", value: svg });
+			return;
+		}
+
+		const image = await canvasRef.current.exportImage(
+			exportFormat,
+			useFixedSize ? { width: 320, height: 180 } : undefined,
+		);
+		setExportResult({ format: exportFormat, value: image });
+	};
+
+	const handleClearOutputClick = () => {
+		setExportResult(null);
+	};
+
+	const backgroundImage = backgroundSources[backgroundSource];
+	const showFallbackNote =
+		backgroundSource === "inaccessible" &&
+		exportWithBackgroundImage &&
+		exportFormat !== "svg";
+
+	return (
+		<div className="d-flex flex-column gap-3 p-2">
+			<section>
+				<h1>Export options</h1>
+				<div className="row g-2">
+					<div className="col-md-4">
+						<label htmlFor="backgroundSource" className="form-label">
+							Background source
+						</label>
+						<select
+							id="backgroundSource"
+							className="form-select form-select-sm"
+							value={backgroundSource}
+							onChange={handleBackgroundSourceChange}
+						>
+							<option value="remote">Remote image URL</option>
+							<option value="dataUri">Data URI</option>
+							<option value="inaccessible">Inaccessible URL</option>
+						</select>
+					</div>
+					<div className="col-md-4">
+						<label htmlFor="exportFormat" className="form-label">
+							Export format
+						</label>
+						<select
+							id="exportFormat"
+							className="form-select form-select-sm"
+							value={exportFormat}
+							onChange={handleExportFormatChange}
+						>
+							<option value="png">PNG</option>
+							<option value="jpeg">JPEG</option>
+							<option value="svg">SVG</option>
+						</select>
+					</div>
+					<div className="col-md-4 d-flex flex-column justify-content-end gap-2">
+						<div className="form-check">
+							<input
+								id="exportWithBackgroundImage"
+								className="form-check-input"
+								type="checkbox"
+								checked={exportWithBackgroundImage}
+								onChange={handleExportWithBackgroundChange}
+							/>
+							<label
+								htmlFor="exportWithBackgroundImage"
+								className="form-check-label"
+							>
+								Include background image
+							</label>
+						</div>
+						<div className="form-check">
+							<input
+								id="useFixedSize"
+								className="form-check-input"
+								type="checkbox"
+								checked={useFixedSize}
+								disabled={exportFormat === "svg"}
+								onChange={handleFixedSizeChange}
+							/>
+							<label htmlFor="useFixedSize" className="form-check-label">
+								Export raster as 320 x 180
+							</label>
+						</div>
+					</div>
+				</div>
+				<div className="d-flex gap-2 mt-3">
+					<button
+						type="button"
+						className="btn btn-sm btn-primary"
+						onClick={handleExportClick}
+					>
+						Export
+					</button>
+					<button
+						type="button"
+						className="btn btn-sm btn-outline-secondary"
+						onClick={handleClearOutputClick}
+					>
+						Clear output
+					</button>
+				</div>
+				{showFallbackNote ? (
+					<p className="alert alert-warning py-2 mt-3 mb-0">
+						If the browser cannot load the background image for export, the
+						drawing can still export without that background layer.
+					</p>
+				) : null}
+			</section>
+
+			<section>
+				<h1>Canvas</h1>
+				<ReactSketchCanvas
+					ref={canvasRef}
+					height="240px"
+					backgroundImage={backgroundImage}
+					canvasColor="#f8fafc"
+					exportWithBackgroundImage={exportWithBackgroundImage}
+					preserveBackgroundImageAspectRatio="xMidYMid slice"
+					strokeWidth={5}
+					strokeColor="#111827"
+				/>
+			</section>
+
+			{exportResult ? (
+				<section>
+					<h1>Export output</h1>
+					{exportResult.format === "svg" ? (
+						<textarea
+							className="form-control font-monospace"
+							readOnly
+							rows={6}
+							value={exportResult.value}
+						/>
+					) : (
+						<img
+							className="img-fluid border rounded"
+							src={exportResult.value}
+							alt={`${exportResult.format.toUpperCase()} export preview`}
+						/>
+					)}
+				</section>
+			) : null}
+		</div>
+	);
+}

--- a/packages/react-sketch-canvas/playwright/e2e/canvas.spec.ts
+++ b/packages/react-sketch-canvas/playwright/e2e/canvas.spec.ts
@@ -118,7 +118,9 @@ test("supports eraser mode with undo and redo controls", async ({ page }) => {
 	await expect(canvas.locator("#rsc__eraser-stroke-group path")).toHaveCount(1);
 
 	await page.locator("#export-svg-button").click();
-	await expect(page.locator("#exported-svg")).toContainText("rsc__eraser-0");
+	await expect(page.locator("#exported-svg")).toContainText(
+		/rsc__export-\d+__eraser-0/,
+	);
 	await expect(page.locator("#exported-svg")).not.toContainText("undefined");
 });
 

--- a/packages/react-sketch-canvas/src/Canvas/export/backgroundLayer.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/backgroundLayer.ts
@@ -79,15 +79,13 @@ function isSvgDataUri(url: string): boolean {
 }
 
 function decodeSvgDataUri(url: string): string | null {
-	const match = /^data:image\/svg\+xml(?<metadata>[^,]*),(?<data>.*)$/i.exec(
-		url,
-	);
+	const match = /^data:image\/svg\+xml([^,]*),(.*)$/i.exec(url);
 
-	if (!match?.groups) {
+	if (!match) {
 		return null;
 	}
 
-	const { metadata, data } = match.groups;
+	const [, metadata = "", data = ""] = match;
 
 	try {
 		if (metadata.includes(";base64")) {

--- a/packages/react-sketch-canvas/src/Canvas/export/backgroundLayer.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/backgroundLayer.ts
@@ -1,0 +1,355 @@
+import type * as React from "react";
+import { encodeSvgDataUrl } from "./encoding";
+import { loadImage } from "./imageLoader";
+
+type PreserveAspectRatio =
+	React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"];
+
+type BackgroundLayerPlan =
+	| { kind: "none" }
+	| {
+			kind: "direct-image";
+			backgroundImage: string;
+			preserveAspectRatio: PreserveAspectRatio;
+	  }
+	| {
+			kind: "svg-wrapper";
+			backgroundImage: string;
+			exportWidth: number;
+			exportHeight: number;
+			preserveAspectRatio: PreserveAspectRatio;
+	  };
+
+type ResolveBackgroundLayerPlanParams = {
+	backgroundImage: string;
+	exportWithBackgroundImage: boolean;
+	exportWidth: number;
+	exportHeight: number;
+	preserveAspectRatio: PreserveAspectRatio;
+};
+
+type DrawDirectImageLayerParams = {
+	context: CanvasRenderingContext2D;
+	backgroundLayer: HTMLImageElement;
+	exportWidth: number;
+	exportHeight: number;
+	preserveAspectRatio: PreserveAspectRatio;
+};
+
+type LoadBackgroundLayerReturns = Promise<HTMLImageElement | null>;
+
+type DrawBackgroundLayerParams = {
+	context: CanvasRenderingContext2D;
+	backgroundLayer: HTMLImageElement;
+	plan: Exclude<BackgroundLayerPlan, { kind: "none" }>;
+	exportWidth: number;
+	exportHeight: number;
+};
+
+export function resolveBackgroundLayerPlan({
+	backgroundImage,
+	exportWithBackgroundImage,
+	exportWidth,
+	exportHeight,
+	preserveAspectRatio,
+}: ResolveBackgroundLayerPlanParams): BackgroundLayerPlan {
+	if (!exportWithBackgroundImage || !backgroundImage) {
+		return { kind: "none" };
+	}
+
+	if (isSvgDataUri(backgroundImage)) {
+		return {
+			kind: "svg-wrapper",
+			backgroundImage,
+			exportWidth,
+			exportHeight,
+			preserveAspectRatio,
+		};
+	}
+
+	return {
+		kind: "direct-image",
+		backgroundImage,
+		preserveAspectRatio,
+	};
+}
+
+function isSvgDataUri(url: string): boolean {
+	return /^data:image\/svg\+xml(?:[;,]|$)/i.test(url);
+}
+
+function decodeSvgDataUri(url: string): string | null {
+	const match = /^data:image\/svg\+xml(?<metadata>[^,]*),(?<data>.*)$/i.exec(
+		url,
+	);
+
+	if (!match?.groups) {
+		return null;
+	}
+
+	const { metadata, data } = match.groups;
+
+	try {
+		if (metadata.includes(";base64")) {
+			return decodeURIComponent(escape(atob(data)));
+		}
+
+		return decodeURIComponent(data);
+	} catch {
+		return null;
+	}
+}
+
+function normalizeSvgDataUriDimensions(url: string): string {
+	const svgText = decodeSvgDataUri(url);
+
+	if (!svgText) {
+		return url;
+	}
+
+	const document = new DOMParser().parseFromString(svgText, "image/svg+xml");
+	const svgElement = document.documentElement;
+
+	if (svgElement.nodeName.toLowerCase() !== "svg") {
+		return url;
+	}
+
+	if (svgElement.hasAttribute("width") && svgElement.hasAttribute("height")) {
+		return url;
+	}
+
+	const viewBox = svgElement.getAttribute("viewBox");
+
+	if (!viewBox) {
+		return url;
+	}
+
+	const [, , width, height] = viewBox
+		.trim()
+		.split(/[\s,]+/)
+		.map(Number);
+
+	if (!Number.isFinite(width) || !Number.isFinite(height)) {
+		return url;
+	}
+
+	if (!svgElement.hasAttribute("width")) {
+		svgElement.setAttribute("width", String(width));
+	}
+
+	if (!svgElement.hasAttribute("height")) {
+		svgElement.setAttribute("height", String(height));
+	}
+
+	const serializedSvg = new XMLSerializer().serializeToString(svgElement);
+
+	return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(serializedSvg)}`;
+}
+
+function createSvgBackgroundLayer({
+	backgroundImage,
+	exportWidth,
+	exportHeight,
+	preserveAspectRatio,
+}: Extract<BackgroundLayerPlan, { kind: "svg-wrapper" }>): SVGElement {
+	const svgNamespace = "http://www.w3.org/2000/svg";
+	const svg = document.createElementNS(svgNamespace, "svg");
+	const defs = document.createElementNS(svgNamespace, "defs");
+	const pattern = document.createElementNS(svgNamespace, "pattern");
+	const image = document.createElementNS(svgNamespace, "image");
+	const rect = document.createElementNS(svgNamespace, "rect");
+
+	svg.setAttribute("xmlns", svgNamespace);
+	svg.setAttribute("width", String(exportWidth));
+	svg.setAttribute("height", String(exportHeight));
+	svg.setAttribute("viewBox", `0 0 ${exportWidth} ${exportHeight}`);
+
+	pattern.setAttribute("id", "react-sketch-canvas-export-background");
+	pattern.setAttribute("x", "0");
+	pattern.setAttribute("y", "0");
+	pattern.setAttribute("width", "100%");
+	pattern.setAttribute("height", "100%");
+	pattern.setAttribute("patternUnits", "userSpaceOnUse");
+
+	image.setAttribute("x", "0");
+	image.setAttribute("y", "0");
+	image.setAttribute("width", "100%");
+	image.setAttribute("height", "100%");
+	image.setAttribute("href", backgroundImage);
+
+	if (preserveAspectRatio) {
+		image.setAttribute("preserveAspectRatio", preserveAspectRatio);
+	}
+
+	rect.setAttribute("x", "0");
+	rect.setAttribute("y", "0");
+	rect.setAttribute("width", "100%");
+	rect.setAttribute("height", "100%");
+	rect.setAttribute("fill", "url(#react-sketch-canvas-export-background)");
+
+	pattern.append(image);
+	defs.append(pattern);
+	svg.append(defs, rect);
+
+	return svg;
+}
+
+type SvgAspectRatioAlign = "Min" | "Mid" | "Max";
+
+type SvgAspectRatioMode = "meet" | "slice";
+
+type ParsedSvgAspectRatio = {
+	xAlign: SvgAspectRatioAlign;
+	yAlign: SvgAspectRatioAlign;
+	mode: SvgAspectRatioMode;
+};
+
+function parseSvgAspectRatio(
+	preserveAspectRatio: PreserveAspectRatio,
+): ParsedSvgAspectRatio | null {
+	if (!preserveAspectRatio || preserveAspectRatio === "none") {
+		return null;
+	}
+
+	const [align = "xMidYMid", mode = "meet"] = preserveAspectRatio.split(/\s+/);
+	const alignMatch = /^x(Min|Mid|Max)Y(Min|Mid|Max)$/.exec(align);
+
+	return {
+		xAlign: (alignMatch?.[1] ?? "Mid") as SvgAspectRatioAlign,
+		yAlign: (alignMatch?.[2] ?? "Mid") as SvgAspectRatioAlign,
+		mode: mode === "slice" ? "slice" : "meet",
+	};
+}
+
+function resolveAlignedOffset(
+	containerSize: number,
+	contentSize: number,
+	align: SvgAspectRatioAlign,
+): number {
+	if (align === "Min") {
+		return 0;
+	}
+
+	const remainingSize = containerSize - contentSize;
+
+	if (align === "Max") {
+		return remainingSize;
+	}
+
+	return remainingSize / 2;
+}
+
+function drawDirectImageLayer({
+	context,
+	backgroundLayer,
+	exportWidth,
+	exportHeight,
+	preserveAspectRatio,
+}: DrawDirectImageLayerParams): void {
+	const parsedAspectRatio = parseSvgAspectRatio(preserveAspectRatio);
+	const sourceWidth = backgroundLayer.naturalWidth || backgroundLayer.width;
+	const sourceHeight = backgroundLayer.naturalHeight || backgroundLayer.height;
+
+	if (!parsedAspectRatio || sourceWidth <= 0 || sourceHeight <= 0) {
+		context.drawImage(backgroundLayer, 0, 0, exportWidth, exportHeight);
+		return;
+	}
+
+	const widthScale = exportWidth / sourceWidth;
+	const heightScale = exportHeight / sourceHeight;
+
+	if (parsedAspectRatio.mode === "slice") {
+		const scale = Math.max(widthScale, heightScale);
+		const sourceCropWidth = exportWidth / scale;
+		const sourceCropHeight = exportHeight / scale;
+		const sourceX = resolveAlignedOffset(
+			sourceWidth,
+			sourceCropWidth,
+			parsedAspectRatio.xAlign,
+		);
+		const sourceY = resolveAlignedOffset(
+			sourceHeight,
+			sourceCropHeight,
+			parsedAspectRatio.yAlign,
+		);
+
+		context.drawImage(
+			backgroundLayer,
+			sourceX,
+			sourceY,
+			sourceCropWidth,
+			sourceCropHeight,
+			0,
+			0,
+			exportWidth,
+			exportHeight,
+		);
+		return;
+	}
+
+	const scale = Math.min(widthScale, heightScale);
+	const destinationWidth = sourceWidth * scale;
+	const destinationHeight = sourceHeight * scale;
+	const destinationX = resolveAlignedOffset(
+		exportWidth,
+		destinationWidth,
+		parsedAspectRatio.xAlign,
+	);
+	const destinationY = resolveAlignedOffset(
+		exportHeight,
+		destinationHeight,
+		parsedAspectRatio.yAlign,
+	);
+
+	context.drawImage(
+		backgroundLayer,
+		destinationX,
+		destinationY,
+		destinationWidth,
+		destinationHeight,
+	);
+}
+
+export async function loadBackgroundLayer(
+	plan: BackgroundLayerPlan,
+): LoadBackgroundLayerReturns {
+	try {
+		if (plan.kind === "none") {
+			return null;
+		}
+
+		if (plan.kind === "svg-wrapper") {
+			const backgroundSvg = createSvgBackgroundLayer(plan);
+
+			return await loadImage(encodeSvgDataUrl(backgroundSvg));
+		}
+
+		return await loadImage(normalizeSvgDataUriDimensions(plan.backgroundImage));
+	} catch {
+		console.warn(
+			"React Sketch Canvas could not load the background image while exporting. Check that backgroundImage points to a reachable image and allows cross-origin access.",
+		);
+		return null;
+	}
+}
+
+export function drawBackgroundLayer({
+	context,
+	backgroundLayer,
+	plan,
+	exportWidth,
+	exportHeight,
+}: DrawBackgroundLayerParams): void {
+	if (plan.kind === "svg-wrapper") {
+		context.drawImage(backgroundLayer, 0, 0, exportWidth, exportHeight);
+		return;
+	}
+
+	drawDirectImageLayer({
+		context,
+		backgroundLayer,
+		exportWidth,
+		exportHeight,
+		preserveAspectRatio: plan.preserveAspectRatio,
+	});
+}

--- a/packages/react-sketch-canvas/src/Canvas/export/encoding.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/encoding.ts
@@ -1,0 +1,9 @@
+/**
+ * Encode an SVG element as an image data URL that can be loaded into `<canvas>`.
+ */
+export function encodeSvgDataUrl(svgCanvas: SVGElement): string {
+	const serializedSvg = new XMLSerializer().serializeToString(svgCanvas);
+	const encodedSvg = btoa(unescape(encodeURIComponent(serializedSvg)));
+
+	return `data:image/svg+xml;base64,${encodedSvg}`;
+}

--- a/packages/react-sketch-canvas/src/Canvas/export/image.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/image.ts
@@ -1,3 +1,4 @@
+import type * as React from "react";
 import type { ExportImageOptions, ExportImageType } from "../../types";
 import { prepareSvgForExport, removeBackgroundImageFromSvg } from "./svg";
 
@@ -36,13 +37,15 @@ function shouldUseAnonymousCrossOrigin(url: string): boolean {
  * Decide whether a configured background image must be painted outside the SVG.
  *
  * @remarks
- * Embedded data/blob URLs can stay inside the serialized SVG layer, preserving
- * SVG image sizing and avoiding an extra duplicate raster draw. External image
- * URLs are painted separately because browsers do not reliably load external
- * resources from an SVG that is itself being rasterized as an image.
+ * Raster export composites the background as a normal canvas image layer for
+ * every URL type. Keeping data/blob URLs inside the serialized SVG would make
+ * browsers rasterize the SVG pattern themselves, which can tile the background
+ * instead of stretching it to the export dimensions. External image URLs also
+ * need this path because browsers do not reliably load external resources from
+ * an SVG that is itself being rasterized as an image.
  */
 function shouldPaintBackgroundAsRasterLayer(url: string): boolean {
-	return !(url.startsWith("data:") || url.startsWith("blob:"));
+	return url.length > 0;
 }
 
 /**
@@ -83,6 +86,7 @@ type ExportImageFromSvgParams = {
 	canvasColor: string;
 	backgroundImage: string;
 	exportWithBackgroundImage: boolean;
+	preserveBackgroundImageAspectRatio?: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"];
 	options?: ExportImageOptions;
 };
 
@@ -90,6 +94,122 @@ type ExportImageFromSvgParams = {
  * The data URL produced by a raster image export.
  */
 type ExportImageFromSvgReturns = Promise<string>;
+
+type SvgAspectRatioAlign = "Min" | "Mid" | "Max";
+
+type SvgAspectRatioMode = "meet" | "slice";
+
+type ParsedSvgAspectRatio = {
+	xAlign: SvgAspectRatioAlign;
+	yAlign: SvgAspectRatioAlign;
+	mode: SvgAspectRatioMode;
+};
+
+function parseSvgAspectRatio(
+	preserveAspectRatio: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"],
+): ParsedSvgAspectRatio | null {
+	if (!preserveAspectRatio || preserveAspectRatio === "none") {
+		return null;
+	}
+
+	const [align = "xMidYMid", mode = "meet"] = preserveAspectRatio.split(/\s+/);
+	const alignMatch = /^x(Min|Mid|Max)Y(Min|Mid|Max)$/.exec(align);
+
+	return {
+		xAlign: (alignMatch?.[1] ?? "Mid") as SvgAspectRatioAlign,
+		yAlign: (alignMatch?.[2] ?? "Mid") as SvgAspectRatioAlign,
+		mode: mode === "slice" ? "slice" : "meet",
+	};
+}
+
+function resolveAlignedOffset(
+	containerSize: number,
+	contentSize: number,
+	align: SvgAspectRatioAlign,
+): number {
+	if (align === "Min") {
+		return 0;
+	}
+
+	const remainingSize = containerSize - contentSize;
+
+	if (align === "Max") {
+		return remainingSize;
+	}
+
+	return remainingSize / 2;
+}
+
+function drawBackgroundLayer(
+	context: CanvasRenderingContext2D,
+	backgroundLayer: HTMLImageElement,
+	exportWidth: number,
+	exportHeight: number,
+	preserveAspectRatio: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"],
+): void {
+	const parsedAspectRatio = parseSvgAspectRatio(preserveAspectRatio);
+	const sourceWidth = backgroundLayer.naturalWidth || backgroundLayer.width;
+	const sourceHeight = backgroundLayer.naturalHeight || backgroundLayer.height;
+
+	if (!parsedAspectRatio || sourceWidth <= 0 || sourceHeight <= 0) {
+		context.drawImage(backgroundLayer, 0, 0, exportWidth, exportHeight);
+		return;
+	}
+
+	const widthScale = exportWidth / sourceWidth;
+	const heightScale = exportHeight / sourceHeight;
+
+	if (parsedAspectRatio.mode === "slice") {
+		const scale = Math.max(widthScale, heightScale);
+		const sourceCropWidth = exportWidth / scale;
+		const sourceCropHeight = exportHeight / scale;
+		const sourceX = resolveAlignedOffset(
+			sourceWidth,
+			sourceCropWidth,
+			parsedAspectRatio.xAlign,
+		);
+		const sourceY = resolveAlignedOffset(
+			sourceHeight,
+			sourceCropHeight,
+			parsedAspectRatio.yAlign,
+		);
+
+		context.drawImage(
+			backgroundLayer,
+			sourceX,
+			sourceY,
+			sourceCropWidth,
+			sourceCropHeight,
+			0,
+			0,
+			exportWidth,
+			exportHeight,
+		);
+		return;
+	}
+
+	const scale = Math.min(widthScale, heightScale);
+	const destinationWidth = sourceWidth * scale;
+	const destinationHeight = sourceHeight * scale;
+	const destinationX = resolveAlignedOffset(
+		exportWidth,
+		destinationWidth,
+		parsedAspectRatio.xAlign,
+	);
+	const destinationY = resolveAlignedOffset(
+		exportHeight,
+		destinationHeight,
+		parsedAspectRatio.yAlign,
+	);
+
+	context.drawImage(
+		backgroundLayer,
+		destinationX,
+		destinationY,
+		destinationWidth,
+		destinationHeight,
+	);
+}
 
 /**
  * Arguments used to prepare the stroke-only SVG layer for raster export.
@@ -238,6 +358,7 @@ export async function exportImageFromSvg({
 	canvasColor,
 	backgroundImage,
 	exportWithBackgroundImage,
+	preserveBackgroundImageAspectRatio,
 	options,
 }: ExportImageFromSvgParams): ExportImageFromSvgReturns {
 	const exportWidth = options?.width ?? svgWidth;
@@ -280,7 +401,13 @@ export async function exportImageFromSvg({
 	);
 
 	if (backgroundLayer) {
-		context.drawImage(backgroundLayer, 0, 0, exportWidth, exportHeight);
+		drawBackgroundLayer(
+			context,
+			backgroundLayer,
+			exportWidth,
+			exportHeight,
+			preserveBackgroundImageAspectRatio,
+		);
 	}
 
 	context.drawImage(strokeImage, 0, 0, exportWidth, exportHeight);

--- a/packages/react-sketch-canvas/src/Canvas/export/image.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/image.ts
@@ -33,6 +33,19 @@ function shouldUseAnonymousCrossOrigin(url: string): boolean {
 }
 
 /**
+ * Decide whether a configured background image must be painted outside the SVG.
+ *
+ * @remarks
+ * Embedded data/blob URLs can stay inside the serialized SVG layer, preserving
+ * SVG image sizing and avoiding an extra duplicate raster draw. External image
+ * URLs are painted separately because browsers do not reliably load external
+ * resources from an SVG that is itself being rasterized as an image.
+ */
+function shouldPaintBackgroundAsRasterLayer(url: string): boolean {
+	return !(url.startsWith("data:") || url.startsWith("blob:"));
+}
+
+/**
  * Load an image URL or data URL for canvas export.
  *
  * @remarks
@@ -44,7 +57,7 @@ export const loadImage = (url: string): LoadImageReturns =>
 		const img = new Image();
 
 		if (shouldUseAnonymousCrossOrigin(url)) {
-			img.setAttribute("crossorigin", "anonymous");
+			img.crossOrigin = "anonymous";
 		}
 
 		img.addEventListener("load", () => {
@@ -83,7 +96,11 @@ type ExportImageFromSvgReturns = Promise<string>;
  */
 type PrepareStrokeSvgForRasterExportArgs = Pick<
 	ExportImageFromSvgParams,
-	"id" | "svgCanvas" | "canvasColor" | "exportWithBackgroundImage"
+	| "id"
+	| "svgCanvas"
+	| "canvasColor"
+	| "backgroundImage"
+	| "exportWithBackgroundImage"
 >;
 
 /**
@@ -98,9 +115,19 @@ type PrepareStrokeSvgForRasterExportArgs = Pick<
 function prepareStrokeSvgForRasterExport(
 	params: PrepareStrokeSvgForRasterExportArgs,
 ): SVGElement {
-	const { id, svgCanvas, canvasColor, exportWithBackgroundImage } = params;
+	const {
+		id,
+		svgCanvas,
+		canvasColor,
+		backgroundImage,
+		exportWithBackgroundImage,
+	} = params;
 
-	if (exportWithBackgroundImage) {
+	if (
+		exportWithBackgroundImage &&
+		backgroundImage &&
+		shouldPaintBackgroundAsRasterLayer(backgroundImage)
+	) {
 		const strokeOnlySvg = removeBackgroundImageFromSvg(svgCanvas, id);
 
 		return prepareSvgForExport(strokeOnlySvg, {
@@ -113,7 +140,7 @@ function prepareStrokeSvgForRasterExport(
 	return prepareSvgForExport(svgCanvas, {
 		id,
 		canvasColor,
-		exportWithBackgroundImage: false,
+		exportWithBackgroundImage,
 	});
 }
 
@@ -176,7 +203,11 @@ async function loadBackgroundLayer(
 	backgroundImage: string,
 	exportWithBackgroundImage: boolean,
 ): Promise<HTMLImageElement | null> {
-	if (!exportWithBackgroundImage || !backgroundImage) {
+	if (
+		!exportWithBackgroundImage ||
+		!backgroundImage ||
+		!shouldPaintBackgroundAsRasterLayer(backgroundImage)
+	) {
 		return null;
 	}
 
@@ -215,6 +246,7 @@ export async function exportImageFromSvg({
 		id,
 		svgCanvas,
 		canvasColor,
+		backgroundImage,
 		exportWithBackgroundImage,
 	});
 	const strokeImage = await loadImage(encodeSvgDataUrl(preparedSvg));

--- a/packages/react-sketch-canvas/src/Canvas/export/image.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/image.ts
@@ -1,207 +1,14 @@
 import type * as React from "react";
 import type { ExportImageOptions, ExportImageType } from "../../types";
+import {
+	drawBackgroundLayer,
+	loadBackgroundLayer,
+	resolveBackgroundLayerPlan,
+} from "./backgroundLayer";
+import { encodeSvgDataUrl } from "./encoding";
+import { loadImage } from "./imageLoader";
 import { prepareSvgForExport, removeBackgroundImageFromSvg } from "./svg";
 
-/**
- * The resolved image element produced by browser image loading.
- */
-type LoadImageReturns = Promise<HTMLImageElement>;
-
-/**
- * Decide whether canvas export should request anonymous cross-origin image loading.
- *
- * @remarks
- * Data and blob URLs are already local to the document. Only cross-origin HTTP
- * images need `crossorigin="anonymous"` so the exported canvas can remain
- * readable when the remote server sends compatible CORS headers.
- */
-function shouldUseAnonymousCrossOrigin(url: string): boolean {
-	if (url.startsWith("data:") || url.startsWith("blob:")) {
-		return false;
-	}
-
-	try {
-		const parsedUrl = new URL(url, window.location.href);
-
-		if (!/^https?:$/.test(parsedUrl.protocol)) {
-			return false;
-		}
-
-		return parsedUrl.origin !== window.location.origin;
-	} catch {
-		return false;
-	}
-}
-
-/**
- * Decide whether a configured background image must be painted outside the SVG.
- *
- * @remarks
- * Raster export composites the background as a normal canvas image layer for
- * every URL type. Keeping data/blob URLs inside the serialized SVG would make
- * browsers rasterize the SVG pattern themselves, which can tile the background
- * instead of stretching it to the export dimensions. External image URLs also
- * need this path because browsers do not reliably load external resources from
- * an SVG that is itself being rasterized as an image.
- */
-function shouldPaintBackgroundAsRasterLayer(url: string): boolean {
-	return url.length > 0;
-}
-
-function isSvgDataUri(url: string): boolean {
-	return /^data:image\/svg\+xml(?:[;,]|$)/i.test(url);
-}
-
-function decodeSvgDataUri(url: string): string | null {
-	const match = /^data:image\/svg\+xml(?<metadata>[^,]*),(?<data>.*)$/i.exec(
-		url,
-	);
-
-	if (!match?.groups) {
-		return null;
-	}
-
-	const { metadata, data } = match.groups;
-
-	try {
-		if (metadata.includes(";base64")) {
-			return decodeURIComponent(escape(atob(data)));
-		}
-
-		return decodeURIComponent(data);
-	} catch {
-		return null;
-	}
-}
-
-function normalizeSvgDataUriDimensions(url: string): string {
-	const svgText = decodeSvgDataUri(url);
-
-	if (!svgText) {
-		return url;
-	}
-
-	const document = new DOMParser().parseFromString(svgText, "image/svg+xml");
-	const svgElement = document.documentElement;
-
-	if (svgElement.nodeName.toLowerCase() !== "svg") {
-		return url;
-	}
-
-	if (svgElement.hasAttribute("width") && svgElement.hasAttribute("height")) {
-		return url;
-	}
-
-	const viewBox = svgElement.getAttribute("viewBox");
-
-	if (!viewBox) {
-		return url;
-	}
-
-	const [, , width, height] = viewBox
-		.trim()
-		.split(/[\s,]+/)
-		.map(Number);
-
-	if (!Number.isFinite(width) || !Number.isFinite(height)) {
-		return url;
-	}
-
-	if (!svgElement.hasAttribute("width")) {
-		svgElement.setAttribute("width", String(width));
-	}
-
-	if (!svgElement.hasAttribute("height")) {
-		svgElement.setAttribute("height", String(height));
-	}
-
-	const serializedSvg = new XMLSerializer().serializeToString(svgElement);
-
-	return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(serializedSvg)}`;
-}
-
-function createSvgBackgroundLayer({
-	backgroundImage,
-	exportWidth,
-	exportHeight,
-	preserveAspectRatio,
-}: {
-	backgroundImage: string;
-	exportWidth: number;
-	exportHeight: number;
-	preserveAspectRatio: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"];
-}): SVGElement {
-	const svgNamespace = "http://www.w3.org/2000/svg";
-	const svg = document.createElementNS(svgNamespace, "svg");
-	const defs = document.createElementNS(svgNamespace, "defs");
-	const pattern = document.createElementNS(svgNamespace, "pattern");
-	const image = document.createElementNS(svgNamespace, "image");
-	const rect = document.createElementNS(svgNamespace, "rect");
-
-	svg.setAttribute("xmlns", svgNamespace);
-	svg.setAttribute("width", String(exportWidth));
-	svg.setAttribute("height", String(exportHeight));
-	svg.setAttribute("viewBox", `0 0 ${exportWidth} ${exportHeight}`);
-
-	pattern.setAttribute("id", "react-sketch-canvas-export-background");
-	pattern.setAttribute("x", "0");
-	pattern.setAttribute("y", "0");
-	pattern.setAttribute("width", "100%");
-	pattern.setAttribute("height", "100%");
-	pattern.setAttribute("patternUnits", "userSpaceOnUse");
-
-	image.setAttribute("x", "0");
-	image.setAttribute("y", "0");
-	image.setAttribute("width", "100%");
-	image.setAttribute("height", "100%");
-	image.setAttribute("href", backgroundImage);
-
-	if (preserveAspectRatio) {
-		image.setAttribute("preserveAspectRatio", preserveAspectRatio);
-	}
-
-	rect.setAttribute("x", "0");
-	rect.setAttribute("y", "0");
-	rect.setAttribute("width", "100%");
-	rect.setAttribute("height", "100%");
-	rect.setAttribute("fill", "url(#react-sketch-canvas-export-background)");
-
-	pattern.append(image);
-	defs.append(pattern);
-	svg.append(defs, rect);
-
-	return svg;
-}
-
-/**
- * Load an image URL or data URL for canvas export.
- *
- * @remarks
- * The image is configured for anonymous cross-origin loading so browser canvas
- * security rules allow `toDataURL` when the remote server permits it.
- */
-export const loadImage = (url: string): LoadImageReturns =>
-	new Promise((resolve, reject) => {
-		const img = new Image();
-
-		if (shouldUseAnonymousCrossOrigin(url)) {
-			img.crossOrigin = "anonymous";
-		}
-
-		img.addEventListener("load", () => {
-			if (img.width > 0) {
-				resolve(img);
-				return;
-			}
-			reject(new Error("Image not found"));
-		});
-		img.addEventListener("error", (err) => reject(err));
-		img.src = url;
-	});
-
-/**
- * Arguments required to render a cloned SVG canvas as a raster image.
- */
 type ExportImageFromSvgParams = {
 	id: string;
 	svgCanvas: SVGElement;
@@ -215,131 +22,9 @@ type ExportImageFromSvgParams = {
 	options?: ExportImageOptions;
 };
 
-/**
- * The data URL produced by a raster image export.
- */
 type ExportImageFromSvgReturns = Promise<string>;
 
-type SvgAspectRatioAlign = "Min" | "Mid" | "Max";
-
-type SvgAspectRatioMode = "meet" | "slice";
-
-type ParsedSvgAspectRatio = {
-	xAlign: SvgAspectRatioAlign;
-	yAlign: SvgAspectRatioAlign;
-	mode: SvgAspectRatioMode;
-};
-
-function parseSvgAspectRatio(
-	preserveAspectRatio: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"],
-): ParsedSvgAspectRatio | null {
-	if (!preserveAspectRatio || preserveAspectRatio === "none") {
-		return null;
-	}
-
-	const [align = "xMidYMid", mode = "meet"] = preserveAspectRatio.split(/\s+/);
-	const alignMatch = /^x(Min|Mid|Max)Y(Min|Mid|Max)$/.exec(align);
-
-	return {
-		xAlign: (alignMatch?.[1] ?? "Mid") as SvgAspectRatioAlign,
-		yAlign: (alignMatch?.[2] ?? "Mid") as SvgAspectRatioAlign,
-		mode: mode === "slice" ? "slice" : "meet",
-	};
-}
-
-function resolveAlignedOffset(
-	containerSize: number,
-	contentSize: number,
-	align: SvgAspectRatioAlign,
-): number {
-	if (align === "Min") {
-		return 0;
-	}
-
-	const remainingSize = containerSize - contentSize;
-
-	if (align === "Max") {
-		return remainingSize;
-	}
-
-	return remainingSize / 2;
-}
-
-function drawBackgroundLayer(
-	context: CanvasRenderingContext2D,
-	backgroundLayer: HTMLImageElement,
-	exportWidth: number,
-	exportHeight: number,
-	preserveAspectRatio: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"],
-): void {
-	const parsedAspectRatio = parseSvgAspectRatio(preserveAspectRatio);
-	const sourceWidth = backgroundLayer.naturalWidth || backgroundLayer.width;
-	const sourceHeight = backgroundLayer.naturalHeight || backgroundLayer.height;
-
-	if (!parsedAspectRatio || sourceWidth <= 0 || sourceHeight <= 0) {
-		context.drawImage(backgroundLayer, 0, 0, exportWidth, exportHeight);
-		return;
-	}
-
-	const widthScale = exportWidth / sourceWidth;
-	const heightScale = exportHeight / sourceHeight;
-
-	if (parsedAspectRatio.mode === "slice") {
-		const scale = Math.max(widthScale, heightScale);
-		const sourceCropWidth = exportWidth / scale;
-		const sourceCropHeight = exportHeight / scale;
-		const sourceX = resolveAlignedOffset(
-			sourceWidth,
-			sourceCropWidth,
-			parsedAspectRatio.xAlign,
-		);
-		const sourceY = resolveAlignedOffset(
-			sourceHeight,
-			sourceCropHeight,
-			parsedAspectRatio.yAlign,
-		);
-
-		context.drawImage(
-			backgroundLayer,
-			sourceX,
-			sourceY,
-			sourceCropWidth,
-			sourceCropHeight,
-			0,
-			0,
-			exportWidth,
-			exportHeight,
-		);
-		return;
-	}
-
-	const scale = Math.min(widthScale, heightScale);
-	const destinationWidth = sourceWidth * scale;
-	const destinationHeight = sourceHeight * scale;
-	const destinationX = resolveAlignedOffset(
-		exportWidth,
-		destinationWidth,
-		parsedAspectRatio.xAlign,
-	);
-	const destinationY = resolveAlignedOffset(
-		exportHeight,
-		destinationHeight,
-		parsedAspectRatio.yAlign,
-	);
-
-	context.drawImage(
-		backgroundLayer,
-		destinationX,
-		destinationY,
-		destinationWidth,
-		destinationHeight,
-	);
-}
-
-/**
- * Arguments used to prepare the stroke-only SVG layer for raster export.
- */
-type PrepareStrokeSvgForRasterExportArgs = Pick<
+type PrepareStrokeSvgForRasterExportParams = Pick<
 	ExportImageFromSvgParams,
 	| "id"
 	| "svgCanvas"
@@ -357,22 +42,14 @@ type PrepareStrokeSvgForRasterExportArgs = Pick<
  * the raster canvas. This avoids duplicate or browser-specific SVG image
  * artifacts while keeping strokes composited above the background.
  */
-function prepareStrokeSvgForRasterExport(
-	params: PrepareStrokeSvgForRasterExportArgs,
-): SVGElement {
-	const {
-		id,
-		svgCanvas,
-		canvasColor,
-		backgroundImage,
-		exportWithBackgroundImage,
-	} = params;
-
-	if (
-		exportWithBackgroundImage &&
-		backgroundImage &&
-		shouldPaintBackgroundAsRasterLayer(backgroundImage)
-	) {
+function prepareStrokeSvgForRasterExport({
+	id,
+	svgCanvas,
+	canvasColor,
+	backgroundImage,
+	exportWithBackgroundImage,
+}: PrepareStrokeSvgForRasterExportParams): SVGElement {
+	if (exportWithBackgroundImage && backgroundImage) {
 		const strokeOnlySvg = removeBackgroundImageFromSvg(svgCanvas, id);
 
 		return prepareSvgForExport(strokeOnlySvg, {
@@ -389,95 +66,18 @@ function prepareStrokeSvgForRasterExport(
 	});
 }
 
-/**
- * Encode an SVG element as an image data URL that can be loaded into `<canvas>`.
- */
-function encodeSvgDataUrl(svgCanvas: SVGElement): string {
-	const serializedSvg = new XMLSerializer().serializeToString(svgCanvas);
-	const encodedSvg = btoa(unescape(encodeURIComponent(serializedSvg)));
-
-	return `data:image/svg+xml;base64,${encodedSvg}`;
-}
-
-/**
- * Resolve the raster scale used for image export.
- *
- * @remarks
- * Explicit export dimensions are treated as final pixel dimensions. Without an
- * explicit size, the export uses the device pixel ratio so default-size exports
- * retain the visual sharpness of the on-screen canvas.
- */
-function resolveRasterScale(options?: ExportImageOptions): number {
-	const hasExplicitSize =
-		options?.width !== undefined || options?.height !== undefined;
-
-	if (hasExplicitSize) {
-		return 1;
-	}
-
-	return Math.max(window.devicePixelRatio || 1, 1);
-}
-
-/**
- * Create the temporary canvas used to composite background and stroke layers.
- */
 function createRasterCanvas(
 	exportWidth: number,
 	exportHeight: number,
-	pixelRatio: number,
 ): HTMLCanvasElement {
 	const renderCanvas = document.createElement("canvas");
 
-	renderCanvas.width = Math.round(exportWidth * pixelRatio);
-	renderCanvas.height = Math.round(exportHeight * pixelRatio);
+	renderCanvas.width = exportWidth;
+	renderCanvas.height = exportHeight;
 	renderCanvas.style.width = `${exportWidth}px`;
 	renderCanvas.style.height = `${exportHeight}px`;
 
 	return renderCanvas;
-}
-
-/**
- * Load the optional background image layer for raster export.
- *
- * @remarks
- * Background image failures are recoverable: consumers still receive the
- * exported stroke layer, and the warning explains what image/CORS settings to
- * check.
- */
-async function loadBackgroundLayer(
-	backgroundImage: string,
-	exportWithBackgroundImage: boolean,
-	exportWidth: number,
-	exportHeight: number,
-	preserveAspectRatio: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"],
-): Promise<HTMLImageElement | null> {
-	if (
-		!exportWithBackgroundImage ||
-		!backgroundImage ||
-		!shouldPaintBackgroundAsRasterLayer(backgroundImage)
-	) {
-		return null;
-	}
-
-	try {
-		if (isSvgDataUri(backgroundImage)) {
-			const backgroundSvg = createSvgBackgroundLayer({
-				backgroundImage,
-				exportWidth,
-				exportHeight,
-				preserveAspectRatio,
-			});
-
-			return await loadImage(encodeSvgDataUrl(backgroundSvg));
-		}
-
-		return await loadImage(normalizeSvgDataUriDimensions(backgroundImage));
-	} catch {
-		console.warn(
-			"React Sketch Canvas could not load the background image while exporting. Check that backgroundImage points to a reachable image and allows cross-origin access.",
-		);
-		return null;
-	}
 }
 
 /**
@@ -502,6 +102,13 @@ export async function exportImageFromSvg({
 }: ExportImageFromSvgParams): ExportImageFromSvgReturns {
 	const exportWidth = options?.width ?? svgWidth;
 	const exportHeight = options?.height ?? svgHeight;
+	const backgroundLayerPlan = resolveBackgroundLayerPlan({
+		backgroundImage,
+		exportWithBackgroundImage,
+		exportWidth,
+		exportHeight,
+		preserveAspectRatio: preserveBackgroundImageAspectRatio,
+	});
 	const preparedSvg = prepareStrokeSvgForRasterExport({
 		id,
 		svgCanvas,
@@ -510,20 +117,11 @@ export async function exportImageFromSvg({
 		exportWithBackgroundImage,
 	});
 	const strokeImage = await loadImage(encodeSvgDataUrl(preparedSvg));
-	const pixelRatio = resolveRasterScale(options);
-	const renderCanvas = createRasterCanvas(
-		exportWidth,
-		exportHeight,
-		pixelRatio,
-	);
+	const renderCanvas = createRasterCanvas(exportWidth, exportHeight);
 	const context = renderCanvas.getContext("2d");
 
 	if (!context) {
 		throw Error("Canvas not rendered yet");
-	}
-
-	if (pixelRatio !== 1) {
-		context.scale(pixelRatio, pixelRatio);
 	}
 
 	const shouldFillCanvasBackground =
@@ -534,26 +132,16 @@ export async function exportImageFromSvg({
 		context.fillRect(0, 0, exportWidth, exportHeight);
 	}
 
-	const backgroundLayer = await loadBackgroundLayer(
-		backgroundImage,
-		exportWithBackgroundImage,
-		exportWidth,
-		exportHeight,
-		preserveBackgroundImageAspectRatio,
-	);
+	const backgroundLayer = await loadBackgroundLayer(backgroundLayerPlan);
 
-	if (backgroundLayer) {
-		if (isSvgDataUri(backgroundImage)) {
-			context.drawImage(backgroundLayer, 0, 0, exportWidth, exportHeight);
-		} else {
-			drawBackgroundLayer(
-				context,
-				backgroundLayer,
-				exportWidth,
-				exportHeight,
-				preserveBackgroundImageAspectRatio,
-			);
-		}
+	if (backgroundLayer && backgroundLayerPlan.kind !== "none") {
+		drawBackgroundLayer({
+			context,
+			backgroundLayer,
+			plan: backgroundLayerPlan,
+			exportWidth,
+			exportHeight,
+		});
 	}
 
 	context.drawImage(strokeImage, 0, 0, exportWidth, exportHeight);

--- a/packages/react-sketch-canvas/src/Canvas/export/image.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/image.ts
@@ -1,6 +1,25 @@
 import type { ExportImageOptions, ExportImageType } from "../../types";
+import { prepareSvgForExport, removeBackgroundImageFromSvg } from "./svg";
 
 type LoadImageReturns = Promise<HTMLImageElement>;
+
+function shouldUseAnonymousCrossOrigin(url: string): boolean {
+	if (url.startsWith("data:") || url.startsWith("blob:")) {
+		return false;
+	}
+
+	try {
+		const parsedUrl = new URL(url, window.location.href);
+
+		if (!/^https?:$/.test(parsedUrl.protocol)) {
+			return false;
+		}
+
+		return parsedUrl.origin !== window.location.origin;
+	} catch {
+		return false;
+	}
+}
 
 /**
  * Load an image URL or data URL for canvas export.
@@ -12,6 +31,11 @@ type LoadImageReturns = Promise<HTMLImageElement>;
 export const loadImage = (url: string): LoadImageReturns =>
 	new Promise((resolve, reject) => {
 		const img = new Image();
+
+		if (shouldUseAnonymousCrossOrigin(url)) {
+			img.setAttribute("crossorigin", "anonymous");
+		}
+
 		img.addEventListener("load", () => {
 			if (img.width > 0) {
 				resolve(img);
@@ -21,10 +45,10 @@ export const loadImage = (url: string): LoadImageReturns =>
 		});
 		img.addEventListener("error", (err) => reject(err));
 		img.src = url;
-		img.setAttribute("crossorigin", "anonymous");
 	});
 
 type ExportImageFromSvgParams = {
+	id: string;
 	svgCanvas: SVGElement;
 	svgWidth: number;
 	svgHeight: number;
@@ -46,6 +70,7 @@ type ExportImageFromSvgReturns = Promise<string>;
  * visible above them.
  */
 export async function exportImageFromSvg({
+	id,
 	svgCanvas,
 	svgWidth,
 	svgHeight,
@@ -57,12 +82,53 @@ export async function exportImageFromSvg({
 }: ExportImageFromSvgParams): ExportImageFromSvgReturns {
 	const exportWidth = options?.width ?? svgWidth;
 	const exportHeight = options?.height ?? svgHeight;
-	const canvasSketch = `data:image/svg+xml;base64,${btoa(svgCanvas.outerHTML)}`;
-	const loadImagePromises = [loadImage(canvasSketch)];
+	const preparedSvg = exportWithBackgroundImage
+		? prepareSvgForExport(removeBackgroundImageFromSvg(svgCanvas, id), {
+				id,
+				canvasColor,
+				exportWithBackgroundImage: true,
+			})
+		: prepareSvgForExport(svgCanvas, {
+				id,
+				canvasColor,
+				exportWithBackgroundImage: false,
+			});
+	const serializedSvg = new XMLSerializer().serializeToString(preparedSvg);
+	const canvasSketch = `data:image/svg+xml;base64,${btoa(
+		unescape(encodeURIComponent(serializedSvg)),
+	)}`;
+	const strokeImage = await loadImage(canvasSketch);
+	const renderCanvas = document.createElement("canvas");
+	const pixelRatio =
+		options?.width !== undefined || options?.height !== undefined
+			? 1
+			: Math.max(window.devicePixelRatio || 1, 1);
+	renderCanvas.width = Math.round(exportWidth * pixelRatio);
+	renderCanvas.height = Math.round(exportHeight * pixelRatio);
+	renderCanvas.style.width = `${exportWidth}px`;
+	renderCanvas.style.height = `${exportHeight}px`;
+	const context = renderCanvas.getContext("2d");
+
+	if (!context) {
+		throw Error("Canvas not rendered yet");
+	}
+
+	if (pixelRatio !== 1) {
+		context.scale(pixelRatio, pixelRatio);
+	}
+
+	const shouldFillCanvasBackground =
+		!backgroundImage || !exportWithBackgroundImage;
+
+	if (shouldFillCanvasBackground) {
+		context.fillStyle = canvasColor;
+		context.fillRect(0, 0, exportWidth, exportHeight);
+	}
 
 	if (exportWithBackgroundImage && backgroundImage) {
 		try {
-			loadImagePromises.push(loadImage(backgroundImage));
+			const backgroundLayer = await loadImage(backgroundImage);
+			context.drawImage(backgroundLayer, 0, 0, exportWidth, exportHeight);
 		} catch {
 			console.warn(
 				"React Sketch Canvas could not load the background image while exporting. Check that backgroundImage points to a reachable image and allows cross-origin access.",
@@ -70,24 +136,7 @@ export async function exportImageFromSvg({
 		}
 	}
 
-	const images = await Promise.all(loadImagePromises);
-	const renderCanvas = document.createElement("canvas");
-	renderCanvas.setAttribute("width", exportWidth.toString());
-	renderCanvas.setAttribute("height", exportHeight.toString());
-	const context = renderCanvas.getContext("2d");
-
-	if (!context) {
-		throw Error("Canvas not rendered yet");
-	}
-
-	if (imageType === "jpeg" && !exportWithBackgroundImage) {
-		context.fillStyle = canvasColor;
-		context.fillRect(0, 0, exportWidth, exportHeight);
-	}
-
-	for (const image of images.reverse()) {
-		context.drawImage(image, 0, 0, exportWidth, exportHeight);
-	}
+	context.drawImage(strokeImage, 0, 0, exportWidth, exportHeight);
 
 	return renderCanvas.toDataURL(`image/${imageType}`);
 }

--- a/packages/react-sketch-canvas/src/Canvas/export/image.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/image.ts
@@ -1,8 +1,19 @@
 import type { ExportImageOptions, ExportImageType } from "../../types";
 import { prepareSvgForExport, removeBackgroundImageFromSvg } from "./svg";
 
+/**
+ * The resolved image element produced by browser image loading.
+ */
 type LoadImageReturns = Promise<HTMLImageElement>;
 
+/**
+ * Decide whether canvas export should request anonymous cross-origin image loading.
+ *
+ * @remarks
+ * Data and blob URLs are already local to the document. Only cross-origin HTTP
+ * images need `crossorigin="anonymous"` so the exported canvas can remain
+ * readable when the remote server sends compatible CORS headers.
+ */
 function shouldUseAnonymousCrossOrigin(url: string): boolean {
 	if (url.startsWith("data:") || url.startsWith("blob:")) {
 		return false;
@@ -47,6 +58,9 @@ export const loadImage = (url: string): LoadImageReturns =>
 		img.src = url;
 	});
 
+/**
+ * Arguments required to render a cloned SVG canvas as a raster image.
+ */
 type ExportImageFromSvgParams = {
 	id: string;
 	svgCanvas: SVGElement;
@@ -59,7 +73,122 @@ type ExportImageFromSvgParams = {
 	options?: ExportImageOptions;
 };
 
+/**
+ * The data URL produced by a raster image export.
+ */
 type ExportImageFromSvgReturns = Promise<string>;
+
+/**
+ * Arguments used to prepare the stroke-only SVG layer for raster export.
+ */
+type PrepareStrokeSvgForRasterExportArgs = Pick<
+	ExportImageFromSvgParams,
+	"id" | "svgCanvas" | "canvasColor" | "exportWithBackgroundImage"
+>;
+
+/**
+ * Prepare the SVG layer that will be rasterized above the background.
+ *
+ * @remarks
+ * When background image export is enabled, the background image markup is
+ * removed from the serialized SVG because the image is painted separately onto
+ * the raster canvas. This avoids duplicate or browser-specific SVG image
+ * artifacts while keeping strokes composited above the background.
+ */
+function prepareStrokeSvgForRasterExport(
+	params: PrepareStrokeSvgForRasterExportArgs,
+): SVGElement {
+	const { id, svgCanvas, canvasColor, exportWithBackgroundImage } = params;
+
+	if (exportWithBackgroundImage) {
+		const strokeOnlySvg = removeBackgroundImageFromSvg(svgCanvas, id);
+
+		return prepareSvgForExport(strokeOnlySvg, {
+			id,
+			canvasColor,
+			exportWithBackgroundImage: true,
+		});
+	}
+
+	return prepareSvgForExport(svgCanvas, {
+		id,
+		canvasColor,
+		exportWithBackgroundImage: false,
+	});
+}
+
+/**
+ * Encode an SVG element as an image data URL that can be loaded into `<canvas>`.
+ */
+function encodeSvgDataUrl(svgCanvas: SVGElement): string {
+	const serializedSvg = new XMLSerializer().serializeToString(svgCanvas);
+	const encodedSvg = btoa(unescape(encodeURIComponent(serializedSvg)));
+
+	return `data:image/svg+xml;base64,${encodedSvg}`;
+}
+
+/**
+ * Resolve the raster scale used for image export.
+ *
+ * @remarks
+ * Explicit export dimensions are treated as final pixel dimensions. Without an
+ * explicit size, the export uses the device pixel ratio so default-size exports
+ * retain the visual sharpness of the on-screen canvas.
+ */
+function resolveRasterScale(options?: ExportImageOptions): number {
+	const hasExplicitSize =
+		options?.width !== undefined || options?.height !== undefined;
+
+	if (hasExplicitSize) {
+		return 1;
+	}
+
+	return Math.max(window.devicePixelRatio || 1, 1);
+}
+
+/**
+ * Create the temporary canvas used to composite background and stroke layers.
+ */
+function createRasterCanvas(
+	exportWidth: number,
+	exportHeight: number,
+	pixelRatio: number,
+): HTMLCanvasElement {
+	const renderCanvas = document.createElement("canvas");
+
+	renderCanvas.width = Math.round(exportWidth * pixelRatio);
+	renderCanvas.height = Math.round(exportHeight * pixelRatio);
+	renderCanvas.style.width = `${exportWidth}px`;
+	renderCanvas.style.height = `${exportHeight}px`;
+
+	return renderCanvas;
+}
+
+/**
+ * Load the optional background image layer for raster export.
+ *
+ * @remarks
+ * Background image failures are recoverable: consumers still receive the
+ * exported stroke layer, and the warning explains what image/CORS settings to
+ * check.
+ */
+async function loadBackgroundLayer(
+	backgroundImage: string,
+	exportWithBackgroundImage: boolean,
+): Promise<HTMLImageElement | null> {
+	if (!exportWithBackgroundImage || !backgroundImage) {
+		return null;
+	}
+
+	try {
+		return await loadImage(backgroundImage);
+	} catch {
+		console.warn(
+			"React Sketch Canvas could not load the background image while exporting. Check that backgroundImage points to a reachable image and allows cross-origin access.",
+		);
+		return null;
+	}
+}
 
 /**
  * Render a cloned SVG canvas into a raster image data URL.
@@ -82,31 +211,19 @@ export async function exportImageFromSvg({
 }: ExportImageFromSvgParams): ExportImageFromSvgReturns {
 	const exportWidth = options?.width ?? svgWidth;
 	const exportHeight = options?.height ?? svgHeight;
-	const preparedSvg = exportWithBackgroundImage
-		? prepareSvgForExport(removeBackgroundImageFromSvg(svgCanvas, id), {
-				id,
-				canvasColor,
-				exportWithBackgroundImage: true,
-			})
-		: prepareSvgForExport(svgCanvas, {
-				id,
-				canvasColor,
-				exportWithBackgroundImage: false,
-			});
-	const serializedSvg = new XMLSerializer().serializeToString(preparedSvg);
-	const canvasSketch = `data:image/svg+xml;base64,${btoa(
-		unescape(encodeURIComponent(serializedSvg)),
-	)}`;
-	const strokeImage = await loadImage(canvasSketch);
-	const renderCanvas = document.createElement("canvas");
-	const pixelRatio =
-		options?.width !== undefined || options?.height !== undefined
-			? 1
-			: Math.max(window.devicePixelRatio || 1, 1);
-	renderCanvas.width = Math.round(exportWidth * pixelRatio);
-	renderCanvas.height = Math.round(exportHeight * pixelRatio);
-	renderCanvas.style.width = `${exportWidth}px`;
-	renderCanvas.style.height = `${exportHeight}px`;
+	const preparedSvg = prepareStrokeSvgForRasterExport({
+		id,
+		svgCanvas,
+		canvasColor,
+		exportWithBackgroundImage,
+	});
+	const strokeImage = await loadImage(encodeSvgDataUrl(preparedSvg));
+	const pixelRatio = resolveRasterScale(options);
+	const renderCanvas = createRasterCanvas(
+		exportWidth,
+		exportHeight,
+		pixelRatio,
+	);
 	const context = renderCanvas.getContext("2d");
 
 	if (!context) {
@@ -125,15 +242,13 @@ export async function exportImageFromSvg({
 		context.fillRect(0, 0, exportWidth, exportHeight);
 	}
 
-	if (exportWithBackgroundImage && backgroundImage) {
-		try {
-			const backgroundLayer = await loadImage(backgroundImage);
-			context.drawImage(backgroundLayer, 0, 0, exportWidth, exportHeight);
-		} catch {
-			console.warn(
-				"React Sketch Canvas could not load the background image while exporting. Check that backgroundImage points to a reachable image and allows cross-origin access.",
-			);
-		}
+	const backgroundLayer = await loadBackgroundLayer(
+		backgroundImage,
+		exportWithBackgroundImage,
+	);
+
+	if (backgroundLayer) {
+		context.drawImage(backgroundLayer, 0, 0, exportWidth, exportHeight);
 	}
 
 	context.drawImage(strokeImage, 0, 0, exportWidth, exportHeight);

--- a/packages/react-sketch-canvas/src/Canvas/export/image.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/image.ts
@@ -48,6 +48,131 @@ function shouldPaintBackgroundAsRasterLayer(url: string): boolean {
 	return url.length > 0;
 }
 
+function isSvgDataUri(url: string): boolean {
+	return /^data:image\/svg\+xml(?:[;,]|$)/i.test(url);
+}
+
+function decodeSvgDataUri(url: string): string | null {
+	const match = /^data:image\/svg\+xml(?<metadata>[^,]*),(?<data>.*)$/i.exec(
+		url,
+	);
+
+	if (!match?.groups) {
+		return null;
+	}
+
+	const { metadata, data } = match.groups;
+
+	try {
+		if (metadata.includes(";base64")) {
+			return decodeURIComponent(escape(atob(data)));
+		}
+
+		return decodeURIComponent(data);
+	} catch {
+		return null;
+	}
+}
+
+function normalizeSvgDataUriDimensions(url: string): string {
+	const svgText = decodeSvgDataUri(url);
+
+	if (!svgText) {
+		return url;
+	}
+
+	const document = new DOMParser().parseFromString(svgText, "image/svg+xml");
+	const svgElement = document.documentElement;
+
+	if (svgElement.nodeName.toLowerCase() !== "svg") {
+		return url;
+	}
+
+	if (svgElement.hasAttribute("width") && svgElement.hasAttribute("height")) {
+		return url;
+	}
+
+	const viewBox = svgElement.getAttribute("viewBox");
+
+	if (!viewBox) {
+		return url;
+	}
+
+	const [, , width, height] = viewBox
+		.trim()
+		.split(/[\s,]+/)
+		.map(Number);
+
+	if (!Number.isFinite(width) || !Number.isFinite(height)) {
+		return url;
+	}
+
+	if (!svgElement.hasAttribute("width")) {
+		svgElement.setAttribute("width", String(width));
+	}
+
+	if (!svgElement.hasAttribute("height")) {
+		svgElement.setAttribute("height", String(height));
+	}
+
+	const serializedSvg = new XMLSerializer().serializeToString(svgElement);
+
+	return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(serializedSvg)}`;
+}
+
+function createSvgBackgroundLayer({
+	backgroundImage,
+	exportWidth,
+	exportHeight,
+	preserveAspectRatio,
+}: {
+	backgroundImage: string;
+	exportWidth: number;
+	exportHeight: number;
+	preserveAspectRatio: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"];
+}): SVGElement {
+	const svgNamespace = "http://www.w3.org/2000/svg";
+	const svg = document.createElementNS(svgNamespace, "svg");
+	const defs = document.createElementNS(svgNamespace, "defs");
+	const pattern = document.createElementNS(svgNamespace, "pattern");
+	const image = document.createElementNS(svgNamespace, "image");
+	const rect = document.createElementNS(svgNamespace, "rect");
+
+	svg.setAttribute("xmlns", svgNamespace);
+	svg.setAttribute("width", String(exportWidth));
+	svg.setAttribute("height", String(exportHeight));
+	svg.setAttribute("viewBox", `0 0 ${exportWidth} ${exportHeight}`);
+
+	pattern.setAttribute("id", "react-sketch-canvas-export-background");
+	pattern.setAttribute("x", "0");
+	pattern.setAttribute("y", "0");
+	pattern.setAttribute("width", "100%");
+	pattern.setAttribute("height", "100%");
+	pattern.setAttribute("patternUnits", "userSpaceOnUse");
+
+	image.setAttribute("x", "0");
+	image.setAttribute("y", "0");
+	image.setAttribute("width", "100%");
+	image.setAttribute("height", "100%");
+	image.setAttribute("href", backgroundImage);
+
+	if (preserveAspectRatio) {
+		image.setAttribute("preserveAspectRatio", preserveAspectRatio);
+	}
+
+	rect.setAttribute("x", "0");
+	rect.setAttribute("y", "0");
+	rect.setAttribute("width", "100%");
+	rect.setAttribute("height", "100%");
+	rect.setAttribute("fill", "url(#react-sketch-canvas-export-background)");
+
+	pattern.append(image);
+	defs.append(pattern);
+	svg.append(defs, rect);
+
+	return svg;
+}
+
 /**
  * Load an image URL or data URL for canvas export.
  *
@@ -322,6 +447,9 @@ function createRasterCanvas(
 async function loadBackgroundLayer(
 	backgroundImage: string,
 	exportWithBackgroundImage: boolean,
+	exportWidth: number,
+	exportHeight: number,
+	preserveAspectRatio: React.SVGAttributes<HTMLImageElement>["preserveAspectRatio"],
 ): Promise<HTMLImageElement | null> {
 	if (
 		!exportWithBackgroundImage ||
@@ -332,7 +460,18 @@ async function loadBackgroundLayer(
 	}
 
 	try {
-		return await loadImage(backgroundImage);
+		if (isSvgDataUri(backgroundImage)) {
+			const backgroundSvg = createSvgBackgroundLayer({
+				backgroundImage,
+				exportWidth,
+				exportHeight,
+				preserveAspectRatio,
+			});
+
+			return await loadImage(encodeSvgDataUrl(backgroundSvg));
+		}
+
+		return await loadImage(normalizeSvgDataUriDimensions(backgroundImage));
 	} catch {
 		console.warn(
 			"React Sketch Canvas could not load the background image while exporting. Check that backgroundImage points to a reachable image and allows cross-origin access.",
@@ -388,7 +527,7 @@ export async function exportImageFromSvg({
 	}
 
 	const shouldFillCanvasBackground =
-		!backgroundImage || !exportWithBackgroundImage;
+		imageType === "jpeg" || !backgroundImage || !exportWithBackgroundImage;
 
 	if (shouldFillCanvasBackground) {
 		context.fillStyle = canvasColor;
@@ -398,16 +537,23 @@ export async function exportImageFromSvg({
 	const backgroundLayer = await loadBackgroundLayer(
 		backgroundImage,
 		exportWithBackgroundImage,
+		exportWidth,
+		exportHeight,
+		preserveBackgroundImageAspectRatio,
 	);
 
 	if (backgroundLayer) {
-		drawBackgroundLayer(
-			context,
-			backgroundLayer,
-			exportWidth,
-			exportHeight,
-			preserveBackgroundImageAspectRatio,
-		);
+		if (isSvgDataUri(backgroundImage)) {
+			context.drawImage(backgroundLayer, 0, 0, exportWidth, exportHeight);
+		} else {
+			drawBackgroundLayer(
+				context,
+				backgroundLayer,
+				exportWidth,
+				exportHeight,
+				preserveBackgroundImageAspectRatio,
+			);
+		}
 	}
 
 	context.drawImage(strokeImage, 0, 0, exportWidth, exportHeight);

--- a/packages/react-sketch-canvas/src/Canvas/export/imageLoader.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/imageLoader.ts
@@ -1,0 +1,56 @@
+/**
+ * The resolved image element produced by browser image loading.
+ */
+type LoadImageReturns = Promise<HTMLImageElement>;
+
+/**
+ * Decide whether canvas export should request anonymous cross-origin image loading.
+ *
+ * @remarks
+ * Data and blob URLs are already local to the document. Only cross-origin HTTP
+ * images need `crossorigin="anonymous"` so the exported canvas can remain
+ * readable when the remote server sends compatible CORS headers.
+ */
+function shouldUseAnonymousCrossOrigin(url: string): boolean {
+	if (url.startsWith("data:") || url.startsWith("blob:")) {
+		return false;
+	}
+
+	try {
+		const parsedUrl = new URL(url, window.location.href);
+
+		if (!/^https?:$/.test(parsedUrl.protocol)) {
+			return false;
+		}
+
+		return parsedUrl.origin !== window.location.origin;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Load an image URL or data URL for canvas export.
+ *
+ * @remarks
+ * The image is configured for anonymous cross-origin loading only when that is
+ * required for a remote HTTP image.
+ */
+export const loadImage = (url: string): LoadImageReturns =>
+	new Promise((resolve, reject) => {
+		const img = new Image();
+
+		if (shouldUseAnonymousCrossOrigin(url)) {
+			img.crossOrigin = "anonymous";
+		}
+
+		img.addEventListener("load", () => {
+			if (img.width > 0) {
+				resolve(img);
+				return;
+			}
+			reject(new Error("Image not found"));
+		});
+		img.addEventListener("error", (err) => reject(err));
+		img.src = url;
+	});

--- a/packages/react-sketch-canvas/src/Canvas/export/svg.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/svg.ts
@@ -1,13 +1,29 @@
-type PrepareSvgForExportParams = {
+/**
+ * Arguments used to prepare a cloned SVG canvas for serialization.
+ */
+type PrepareSvgForExportArgs = {
 	id: string;
 	canvasColor: string;
 	exportWithBackgroundImage: boolean;
 };
 
+/**
+ * The cloned SVG element after export-specific mutations have been applied.
+ */
 type PrepareSvgForExportReturns = SVGElement;
 
 let svgExportNonce = 0;
 
+/**
+ * Rewrite exported SVG ids so the serialized markup can coexist with the live canvas.
+ *
+ * @remarks
+ * The drawing canvas relies on internal ids for masks, background patterns, and
+ * `url(#...)` references. If an exported SVG is later rendered into the same
+ * document, reusing those ids would cause the exported asset and the live
+ * canvas to cross-reference each other. This helper assigns a unique export
+ * prefix and updates every supported attribute that points at those ids.
+ */
 function namespaceSvgInternalIds(svgCanvas: SVGElement, id: string): void {
 	svgExportNonce += 1;
 	const exportPrefix = `${id}__export-${svgExportNonce}`;
@@ -56,6 +72,16 @@ function namespaceSvgInternalIds(svgCanvas: SVGElement, id: string): void {
 	}
 }
 
+/**
+ * Remove background-image-specific SVG nodes from a cloned canvas.
+ *
+ * @remarks
+ * Raster export paints the background image as a separate layer to avoid
+ * browser-specific SVG image artifacts. This helper strips the background
+ * pattern and its visible rect from the cloned SVG so the serialized stroke
+ * layer contains only vector content that should be composited above the
+ * background.
+ */
 export function removeBackgroundImageFromSvg(
 	svgCanvas: SVGElement,
 	id: string,
@@ -77,7 +103,7 @@ export function removeBackgroundImageFromSvg(
  */
 export function prepareSvgForExport(
 	svgCanvas: SVGElement,
-	{ id, canvasColor, exportWithBackgroundImage }: PrepareSvgForExportParams,
+	{ id, canvasColor, exportWithBackgroundImage }: PrepareSvgForExportArgs,
 ): PrepareSvgForExportReturns {
 	if (!exportWithBackgroundImage) {
 		svgCanvas.querySelector(`#${id}__background`)?.remove();

--- a/packages/react-sketch-canvas/src/Canvas/export/svg.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/svg.ts
@@ -6,6 +6,67 @@ type PrepareSvgForExportParams = {
 
 type PrepareSvgForExportReturns = SVGElement;
 
+let svgExportNonce = 0;
+
+function namespaceSvgInternalIds(svgCanvas: SVGElement, id: string): void {
+	svgExportNonce += 1;
+	const exportPrefix = `${id}__export-${svgExportNonce}`;
+	const idMap = new Map<string, string>();
+
+	for (const element of svgCanvas.querySelectorAll("[id]")) {
+		const currentId = element.getAttribute("id");
+
+		if (!currentId?.startsWith(`${id}__`)) {
+			continue;
+		}
+
+		const nextId = currentId.replace(`${id}__`, `${exportPrefix}__`);
+		idMap.set(currentId, nextId);
+		element.setAttribute("id", nextId);
+	}
+
+	const rewriteAttributeValue = (value: string): string => {
+		let nextValue = value;
+
+		for (const [currentId, nextId] of idMap) {
+			nextValue = nextValue.replaceAll(`url(#${currentId})`, `url(#${nextId})`);
+
+			if (nextValue === `#${currentId}`) {
+				nextValue = `#${nextId}`;
+			}
+		}
+
+		return nextValue;
+	};
+
+	for (const element of svgCanvas.querySelectorAll("*")) {
+		for (const attributeName of ["fill", "mask", "href", "xlink:href"]) {
+			const value = element.getAttribute(attributeName);
+
+			if (!value) {
+				continue;
+			}
+
+			const nextValue = rewriteAttributeValue(value);
+
+			if (nextValue !== value) {
+				element.setAttribute(attributeName, nextValue);
+			}
+		}
+	}
+}
+
+export function removeBackgroundImageFromSvg(
+	svgCanvas: SVGElement,
+	id: string,
+): SVGElement {
+	svgCanvas.querySelector(`#${id}__background`)?.remove();
+	svgCanvas.querySelector(`#${id}__canvas-background-group`)?.remove();
+	svgCanvas.querySelector(`#${id}__canvas-background`)?.remove();
+
+	return svgCanvas;
+}
+
 /**
  * Prepare a cloned SVG element for export.
  *
@@ -18,14 +79,14 @@ export function prepareSvgForExport(
 	svgCanvas: SVGElement,
 	{ id, canvasColor, exportWithBackgroundImage }: PrepareSvgForExportParams,
 ): PrepareSvgForExportReturns {
-	if (exportWithBackgroundImage) {
-		return svgCanvas;
+	if (!exportWithBackgroundImage) {
+		svgCanvas.querySelector(`#${id}__background`)?.remove();
+		svgCanvas
+			.querySelector(`#${id}__canvas-background`)
+			?.setAttribute("fill", canvasColor);
 	}
 
-	svgCanvas.querySelector(`#${id}__background`)?.remove();
-	svgCanvas
-		.querySelector(`#${id}__canvas-background`)
-		?.setAttribute("fill", canvasColor);
+	namespaceSvgInternalIds(svgCanvas, id);
 
 	return svgCanvas;
 }

--- a/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasExportHandle.ts
+++ b/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasExportHandle.ts
@@ -8,7 +8,10 @@ import type { CanvasProps, CanvasRef } from "../types";
 type UseCanvasExportHandleParams = Required<Pick<CanvasProps, "id">> &
 	Pick<
 		CanvasProps,
-		"canvasColor" | "backgroundImage" | "exportWithBackgroundImage"
+		| "canvasColor"
+		| "backgroundImage"
+		| "exportWithBackgroundImage"
+		| "preserveBackgroundImageAspectRatio"
 	> & {
 		canvasRef: React.RefObject<HTMLDivElement | null>;
 	};
@@ -30,6 +33,7 @@ export function useCanvasExportHandle(
 		canvasColor,
 		backgroundImage,
 		exportWithBackgroundImage,
+		preserveBackgroundImageAspectRatio,
 	}: UseCanvasExportHandleParams,
 ): UseCanvasExportHandleReturns {
 	React.useImperativeHandle(ref, () => ({
@@ -54,6 +58,7 @@ export function useCanvasExportHandle(
 				canvasColor,
 				backgroundImage,
 				exportWithBackgroundImage,
+				preserveBackgroundImageAspectRatio,
 				options,
 			});
 		},

--- a/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasExportHandle.ts
+++ b/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasExportHandle.ts
@@ -46,6 +46,7 @@ export function useCanvasExportHandle(
 			const { svgCanvas, width, height } = getCanvasWithViewBox(canvas);
 
 			return exportImageFromSvg({
+				id,
 				svgCanvas,
 				svgWidth: width,
 				svgHeight: height,

--- a/packages/react-sketch-canvas/src/Canvas/index.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/index.tsx
@@ -58,6 +58,7 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 		canvasColor,
 		backgroundImage,
 		exportWithBackgroundImage,
+		preserveBackgroundImageAspectRatio,
 	});
 
 	const { handlePointerDown, handlePointerMove, handlePointerUp } =

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx
@@ -52,7 +52,7 @@ export const ReactSketchCanvas = React.forwardRef<
 		readOnly = false,
 	} = props;
 
-	const svgCanvas = React.createRef<CanvasRef>();
+	const svgCanvas = React.useRef<CanvasRef>(null);
 	const {
 		currentPaths,
 		isDrawing,

--- a/packages/react-sketch-canvas/tests/actions/export.spec.tsx
+++ b/packages/react-sketch-canvas/tests/actions/export.spec.tsx
@@ -69,6 +69,10 @@ function dataURIPattern(imageType: ExportImageType) {
 	return new RegExp(`^data:image/${imageType};base64,`);
 }
 
+function exportedIdFragment(idOrSelector: string) {
+	return idOrSelector.replace(/^#?[^_]+__/, "");
+}
+
 function expectValidDataURI(
 	dataURI: string | undefined,
 	imageType: ExportImageType,
@@ -322,7 +326,7 @@ test.describe("export SVG", () => {
 			await drawSquaresAndWaitForStroke(canvas);
 
 			await exportSVGButton.click();
-			expect(svg).toContain(firstStrokePathId.slice(1));
+			expect(svg).toContain(exportedIdFragment(firstStrokePathId));
 		});
 
 		test("should export svg with stroke and eraser", async ({ mount }) => {
@@ -346,14 +350,14 @@ test.describe("export SVG", () => {
 			await drawSquaresAndWaitForStroke(canvas);
 
 			await exportSVGButton.click();
-			expect(svg).toContain(firstStrokePathId.slice(1));
-			expect(svg).not.toContain(firstEraserStrokeId.slice(1));
+			expect(svg).toContain(exportedIdFragment(firstStrokePathId));
+			expect(svg).not.toContain(exportedIdFragment(firstEraserStrokeId));
 
 			await eraserButton.click();
 			await drawSquaresAndWaitForEraser(canvas);
 
 			await exportSVGButton.click();
-			expect(svg).toContain(firstEraserStrokeId.slice(1));
+			expect(svg).toContain(exportedIdFragment(firstEraserStrokeId));
 		});
 	});
 
@@ -375,15 +379,15 @@ test.describe("export SVG", () => {
 
 			await exportSVGButton.click();
 			expect(svg).toContain(backgroundUrl);
-			expect(svg).toContain(canvasBackgroundId.slice(1));
+			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
 			expect(svg).not.toContain(firstStrokePathId.slice(1));
 
 			await drawSquaresAndWaitForStroke(canvas);
 
 			await exportSVGButton.click();
 			expect(svg).toContain(backgroundUrl);
-			expect(svg).toContain(canvasBackgroundId.slice(1));
-			expect(svg).toContain(firstStrokePathId.slice(1));
+			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
+			expect(svg).toContain(exportedIdFragment(firstStrokePathId));
 		});
 
 		test("should export svg with stroke and eraser", async ({ mount }) => {
@@ -405,7 +409,7 @@ test.describe("export SVG", () => {
 
 			await exportSVGButton.click();
 			expect(svg).toContain(backgroundUrl);
-			expect(svg).toContain(canvasBackgroundId.slice(1));
+			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
 			expect(svg).not.toContain(firstStrokePathId.slice(1));
 			expect(svg).not.toContain(firstEraserStrokeId.slice(1));
 
@@ -413,8 +417,8 @@ test.describe("export SVG", () => {
 
 			await exportSVGButton.click();
 			expect(svg).toContain(backgroundUrl);
-			expect(svg).toContain(canvasBackgroundId.slice(1));
-			expect(svg).toContain(firstStrokePathId.slice(1));
+			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
+			expect(svg).toContain(exportedIdFragment(firstStrokePathId));
 			expect(svg).not.toContain(firstEraserStrokeId.slice(1));
 
 			await eraserButton.click();
@@ -422,8 +426,8 @@ test.describe("export SVG", () => {
 
 			await exportSVGButton.click();
 			expect(svg).toContain(backgroundUrl);
-			expect(svg).toContain(canvasBackgroundId.slice(1));
-			expect(svg).toContain(firstEraserStrokeId.slice(1));
+			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
+			expect(svg).toContain(exportedIdFragment(firstEraserStrokeId));
 		});
 	});
 
@@ -451,8 +455,8 @@ test.describe("export SVG", () => {
 
 			await exportSVGButton.click();
 			expect(svg).not.toContain(backgroundUrl);
-			expect(svg).toContain(canvasBackgroundId.slice(1));
-			expect(svg).toContain(firstStrokePathId.slice(1));
+			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
+			expect(svg).toContain(exportedIdFragment(firstStrokePathId));
 		});
 
 		test("should export svg with stroke and eraser", async ({ mount }) => {
@@ -474,7 +478,7 @@ test.describe("export SVG", () => {
 
 			await exportSVGButton.click();
 			expect(svg).not.toContain(backgroundUrl);
-			expect(svg).toContain(canvasBackgroundId.slice(1));
+			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
 			expect(svg).not.toContain(firstStrokePathId.slice(1));
 			expect(svg).not.toContain(firstEraserStrokeId.slice(1));
 
@@ -482,8 +486,8 @@ test.describe("export SVG", () => {
 
 			await exportSVGButton.click();
 			expect(svg).not.toContain(backgroundUrl);
-			expect(svg).toContain(canvasBackgroundId.slice(1));
-			expect(svg).toContain(firstStrokePathId.slice(1));
+			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
+			expect(svg).toContain(exportedIdFragment(firstStrokePathId));
 			expect(svg).not.toContain(firstEraserStrokeId.slice(1));
 
 			await eraserButton.click();
@@ -491,8 +495,8 @@ test.describe("export SVG", () => {
 
 			await exportSVGButton.click();
 			expect(svg).not.toContain(backgroundUrl);
-			expect(svg).toContain(canvasBackgroundId.slice(1));
-			expect(svg).toContain(firstEraserStrokeId.slice(1));
+			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
+			expect(svg).toContain(exportedIdFragment(firstEraserStrokeId));
 		});
 	});
 });

--- a/packages/react-sketch-canvas/tests/actions/export.spec.tsx
+++ b/packages/react-sketch-canvas/tests/actions/export.spec.tsx
@@ -143,6 +143,89 @@ async function getImagePixelAtRatio(
 	);
 }
 
+async function getSvgPixelAtRatio(
+	page: Page,
+	selector: string,
+	xRatio: number,
+	yRatio: number,
+) {
+	return page.evaluate(
+		async ({ selector, xRatio, yRatio }) => {
+			const svg = document.querySelector(selector);
+
+			if (!(svg instanceof SVGSVGElement)) {
+				throw new Error(`SVG not found for selector: ${selector}`);
+			}
+
+			const width = Math.round(svg.clientWidth);
+			const height = Math.round(svg.clientHeight);
+			const svgClone = svg.cloneNode(true) as SVGSVGElement;
+
+			svgClone.setAttribute("width", width.toString());
+			svgClone.setAttribute("height", height.toString());
+			svgClone.setAttribute("viewBox", `0 0 ${width} ${height}`);
+
+			const image = new Image();
+			const url = URL.createObjectURL(
+				new Blob([new XMLSerializer().serializeToString(svgClone)], {
+					type: "image/svg+xml",
+				}),
+			);
+
+			try {
+				await new Promise<void>((resolve, reject) => {
+					image.addEventListener("load", () => resolve(), { once: true });
+					image.addEventListener(
+						"error",
+						() => reject(new Error("SVG image failed to load")),
+						{ once: true },
+					);
+					image.src = url;
+				});
+
+				const canvas = document.createElement("canvas");
+				canvas.width = width;
+				canvas.height = height;
+
+				const context = canvas.getContext("2d");
+
+				if (!context) {
+					throw new Error("2D canvas context unavailable");
+				}
+
+				context.drawImage(image, 0, 0);
+
+				const x = Math.floor(width * xRatio);
+				const y = Math.floor(height * yRatio);
+
+				return Array.from(context.getImageData(x, y, 1, 1).data);
+			} finally {
+				URL.revokeObjectURL(url);
+			}
+		},
+		{ selector, xRatio, yRatio },
+	);
+}
+
+function expectPixelCloseTo(actual: number[], expected: number[]) {
+	for (let index = 0; index < expected.length; index++) {
+		expect(
+			Math.abs((actual[index] ?? 0) - expected[index]),
+		).toBeLessThanOrEqual(6);
+	}
+}
+
+function compositePixelOverWhite(pixel: number[]) {
+	const alpha = (pixel[3] ?? 255) / 255;
+
+	return [
+		Math.round((pixel[0] ?? 0) * alpha + 255 * (1 - alpha)),
+		Math.round((pixel[1] ?? 0) * alpha + 255 * (1 - alpha)),
+		Math.round((pixel[2] ?? 0) * alpha + 255 * (1 - alpha)),
+		255,
+	];
+}
+
 async function drawSquaresAndWaitForStroke(canvas: Locator) {
 	await drawSquares(canvas);
 	await expect(canvas.locator("path")).toHaveCount(expectedStrokeCount);
@@ -160,8 +243,8 @@ const backgroundUrl =
 	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='400'%3E%3Crect width='600' height='400' fill='white'/%3E%3Ccircle cx='300' cy='200' r='120' fill='black'/%3E%3C/svg%3E";
 const splitColorBackgroundUrl =
 	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='2' height='1'%3E%3Crect width='1' height='1' fill='red'/%3E%3Crect x='1' width='1' height='1' fill='lime'/%3E%3C/svg%3E";
-const wideCenterBackgroundUrl =
-	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='1'%3E%3Crect width='1' height='1' fill='red'/%3E%3Crect x='1' width='2' height='1' fill='lime'/%3E%3Crect x='3' width='1' height='1' fill='blue'/%3E%3C/svg%3E";
+const docsDataUriBackgroundUrl =
+	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 360'%3E%3Crect width='640' height='360' fill='%23f8fafc'/%3E%3Cpath d='M0 260 C120 170 220 310 340 220 S540 160 640 230 V360 H0 Z' fill='%23bfdbfe'/%3E%3Ccircle cx='500' cy='95' r='54' fill='%23facc15'/%3E%3Cpath d='M60 110 H300' stroke='%2314b8a6' stroke-width='20' stroke-linecap='round'/%3E%3Cpath d='M60 150 H230' stroke='%23fb7185' stroke-width='20' stroke-linecap='round'/%3E%3C/svg%3E";
 test.describe("exportImage", () => {
 	for (const imageType of ["png", "jpeg"] as const) {
 		test.describe(`exportImage - ${imageType}`, () => {
@@ -234,7 +317,7 @@ test.describe("exportImage", () => {
 					expect(rightPixel[3]).toBe(255);
 				});
 
-				test(`should export ${imageType} with the configured slice background image fit`, async ({
+				test(`should export ${imageType} with a data URI background matching the live canvas`, async ({
 					mount,
 					page,
 				}) => {
@@ -247,37 +330,50 @@ test.describe("exportImage", () => {
 						mount,
 						imageType,
 						handleExportImage,
-						backgroundUrl: wideCenterBackgroundUrl,
+						backgroundUrl: docsDataUriBackgroundUrl,
 						exportWithBackgroundImage: true,
 						preserveBackgroundImageAspectRatio: "xMidYMid slice",
-						width: "320px",
-						height: "320px",
+						width: "600px",
+						height: "240px",
 					});
 
 					await exportImageAndWait(exportButton, () => dataURI, imageType);
 
-					const leftPixel = await getImagePixelAtRatio(
+					const liveTopLeft = await getSvgPixelAtRatio(
+						page,
+						`#${canvasId}`,
+						0.1,
+						0.1,
+					);
+					const exportTopLeft = await getImagePixelAtRatio(
 						page,
 						dataURI ?? "",
 						0.1,
+						0.1,
+					);
+					const liveCenter = await getSvgPixelAtRatio(
+						page,
+						`#${canvasId}`,
+						0.5,
 						0.5,
 					);
-					const rightPixel = await getImagePixelAtRatio(
+					const exportCenter = await getImagePixelAtRatio(
 						page,
 						dataURI ?? "",
-						0.9,
+						0.5,
 						0.5,
 					);
+					const expectedTopLeft =
+						imageType === "jpeg"
+							? compositePixelOverWhite(liveTopLeft)
+							: liveTopLeft;
+					const expectedCenter =
+						imageType === "jpeg"
+							? compositePixelOverWhite(liveCenter)
+							: liveCenter;
 
-					expect(leftPixel[0]).toBeLessThan(120);
-					expect(leftPixel[1]).toBeGreaterThan(180);
-					expect(leftPixel[2]).toBeLessThan(120);
-					expect(leftPixel[3]).toBe(255);
-
-					expect(rightPixel[0]).toBeLessThan(120);
-					expect(rightPixel[1]).toBeGreaterThan(180);
-					expect(rightPixel[2]).toBeLessThan(120);
-					expect(rightPixel[3]).toBe(255);
+					expectPixelCloseTo(exportTopLeft, expectedTopLeft);
+					expectPixelCloseTo(exportCenter, expectedCenter);
 				});
 
 				test(`should export ${imageType} with stroke and eraser`, async ({

--- a/packages/react-sketch-canvas/tests/actions/export.spec.tsx
+++ b/packages/react-sketch-canvas/tests/actions/export.spec.tsx
@@ -3,8 +3,8 @@ import {
 	type MountOptions,
 	test,
 } from "@playwright/experimental-ct-react";
-import type { Locator } from "playwright/test";
-import type { ExportImageType } from "../../src";
+import type { Locator, Page } from "playwright/test";
+import type { ExportImageType, ReactSketchCanvasProps } from "../../src";
 import { drawSquares, getCanvasIds } from "../commands";
 import { WithExportButton } from "../stories/WithExportButton.story";
 
@@ -25,6 +25,9 @@ interface MountCanvasForExportArgs<HooksConfig extends object> {
 	handleExportImage?: (dataURI: string | undefined) => void;
 	backgroundUrl?: string;
 	exportWithBackgroundImage?: boolean;
+	preserveBackgroundImageAspectRatio?: ReactSketchCanvasProps["preserveBackgroundImageAspectRatio"];
+	width?: ReactSketchCanvasProps["width"];
+	height?: ReactSketchCanvasProps["height"];
 	handleExportSVG?: (svg: string | undefined) => void;
 }
 
@@ -35,6 +38,9 @@ async function mountCanvasForExport<HooksConfig extends object>({
 	handleExportImage,
 	backgroundUrl,
 	exportWithBackgroundImage,
+	preserveBackgroundImageAspectRatio,
+	width,
+	height,
 	handleExportSVG,
 }: MountCanvasForExportArgs<HooksConfig>) {
 	const component = await mount(
@@ -48,6 +54,9 @@ async function mountCanvasForExport<HooksConfig extends object>({
 			onExportImage={handleExportImage}
 			backgroundImage={backgroundUrl}
 			exportWithBackgroundImage={exportWithBackgroundImage}
+			preserveBackgroundImageAspectRatio={preserveBackgroundImageAspectRatio}
+			width={width}
+			height={height}
 			onExportSVG={handleExportSVG}
 		/>,
 	);
@@ -93,6 +102,47 @@ async function exportImageAndWait(
 	expectValidDataURI(getDataURI(), imageType);
 }
 
+async function getImagePixelAtRatio(
+	page: Page,
+	dataURI: string,
+	xRatio: number,
+	yRatio: number,
+) {
+	return page.evaluate(
+		async ({ dataURI, xRatio, yRatio }) => {
+			const image = new Image();
+
+			await new Promise<void>((resolve, reject) => {
+				image.addEventListener("load", () => resolve(), { once: true });
+				image.addEventListener(
+					"error",
+					() => reject(new Error("Exported image failed to load")),
+					{ once: true },
+				);
+				image.src = dataURI;
+			});
+
+			const canvas = document.createElement("canvas");
+			canvas.width = image.naturalWidth;
+			canvas.height = image.naturalHeight;
+
+			const context = canvas.getContext("2d");
+
+			if (!context) {
+				throw new Error("2D canvas context unavailable");
+			}
+
+			context.drawImage(image, 0, 0);
+
+			const x = Math.floor(image.naturalWidth * xRatio);
+			const y = Math.floor(image.naturalHeight * yRatio);
+
+			return Array.from(context.getImageData(x, y, 1, 1).data);
+		},
+		{ dataURI, xRatio, yRatio },
+	);
+}
+
 async function drawSquaresAndWaitForStroke(canvas: Locator) {
 	await drawSquares(canvas);
 	await expect(canvas.locator("path")).toHaveCount(expectedStrokeCount);
@@ -108,6 +158,10 @@ async function drawSquaresAndWaitForEraser(canvas: Locator) {
 
 const backgroundUrl =
 	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='400'%3E%3Crect width='600' height='400' fill='white'/%3E%3Ccircle cx='300' cy='200' r='120' fill='black'/%3E%3C/svg%3E";
+const splitColorBackgroundUrl =
+	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='2' height='1'%3E%3Crect width='1' height='1' fill='red'/%3E%3Crect x='1' width='1' height='1' fill='lime'/%3E%3C/svg%3E";
+const wideCenterBackgroundUrl =
+	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='1'%3E%3Crect width='1' height='1' fill='red'/%3E%3Crect x='1' width='2' height='1' fill='lime'/%3E%3Crect x='3' width='1' height='1' fill='blue'/%3E%3C/svg%3E";
 test.describe("exportImage", () => {
 	for (const imageType of ["png", "jpeg"] as const) {
 		test.describe(`exportImage - ${imageType}`, () => {
@@ -135,6 +189,95 @@ test.describe("exportImage", () => {
 
 					await exportImageAndWait(exportButton, () => dataURI, imageType);
 					expect(size).toBeGreaterThan(0);
+				});
+
+				test(`should export ${imageType} with a stretched data URI background image`, async ({
+					mount,
+					page,
+				}) => {
+					let dataURI: string | undefined;
+					const handleExportImage = (exportedDataURI: string | undefined) => {
+						dataURI = exportedDataURI;
+					};
+
+					const { exportButton } = await mountCanvasForExport({
+						mount,
+						imageType,
+						handleExportImage,
+						backgroundUrl: splitColorBackgroundUrl,
+						exportWithBackgroundImage: true,
+					});
+
+					await exportImageAndWait(exportButton, () => dataURI, imageType);
+
+					const leftPixel = await getImagePixelAtRatio(
+						page,
+						dataURI ?? "",
+						0.25,
+						0.5,
+					);
+					const rightPixel = await getImagePixelAtRatio(
+						page,
+						dataURI ?? "",
+						0.75,
+						0.5,
+					);
+
+					expect(leftPixel[0]).toBeGreaterThan(200);
+					expect(leftPixel[1]).toBeLessThan(80);
+					expect(leftPixel[2]).toBeLessThan(80);
+					expect(leftPixel[3]).toBe(255);
+
+					expect(rightPixel[0]).toBeLessThan(120);
+					expect(rightPixel[1]).toBeGreaterThan(180);
+					expect(rightPixel[2]).toBeLessThan(120);
+					expect(rightPixel[3]).toBe(255);
+				});
+
+				test(`should export ${imageType} with the configured slice background image fit`, async ({
+					mount,
+					page,
+				}) => {
+					let dataURI: string | undefined;
+					const handleExportImage = (exportedDataURI: string | undefined) => {
+						dataURI = exportedDataURI;
+					};
+
+					const { exportButton } = await mountCanvasForExport({
+						mount,
+						imageType,
+						handleExportImage,
+						backgroundUrl: wideCenterBackgroundUrl,
+						exportWithBackgroundImage: true,
+						preserveBackgroundImageAspectRatio: "xMidYMid slice",
+						width: "320px",
+						height: "320px",
+					});
+
+					await exportImageAndWait(exportButton, () => dataURI, imageType);
+
+					const leftPixel = await getImagePixelAtRatio(
+						page,
+						dataURI ?? "",
+						0.1,
+						0.5,
+					);
+					const rightPixel = await getImagePixelAtRatio(
+						page,
+						dataURI ?? "",
+						0.9,
+						0.5,
+					);
+
+					expect(leftPixel[0]).toBeLessThan(120);
+					expect(leftPixel[1]).toBeGreaterThan(180);
+					expect(leftPixel[2]).toBeLessThan(120);
+					expect(leftPixel[3]).toBe(255);
+
+					expect(rightPixel[0]).toBeLessThan(120);
+					expect(rightPixel[1]).toBeGreaterThan(180);
+					expect(rightPixel[2]).toBeLessThan(120);
+					expect(rightPixel[3]).toBe(255);
 				});
 
 				test(`should export ${imageType} with stroke and eraser`, async ({

--- a/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
@@ -4,6 +4,8 @@ import { exportImageFromSvg } from "../../../src/Canvas/export/image";
 class MockImage {
 	static instances: MockImage[] = [];
 
+	static failingSources = new Set<string>();
+
 	public width = 100;
 
 	public onload: (() => void) | null = null;
@@ -37,6 +39,14 @@ class MockImage {
 	public set src(value: string) {
 		this._src = value;
 		queueMicrotask(() => {
+			if (MockImage.failingSources.has(value)) {
+				for (const listener of this.listeners.get("error") ?? []) {
+					listener();
+				}
+
+				return;
+			}
+
 			for (const listener of this.listeners.get("load") ?? []) {
 				listener();
 			}
@@ -58,6 +68,7 @@ describe("exportImageFromSvg", () => {
 
 	beforeEach(() => {
 		MockImage.instances = [];
+		MockImage.failingSources = new Set();
 		drawImage.mockReset();
 		fillRect.mockReset();
 		globalThis.Image = MockImage as unknown as typeof Image;
@@ -139,5 +150,38 @@ describe("exportImageFromSvg", () => {
 			100,
 		);
 		expect(drawImage).toHaveBeenNthCalledWith(2, strokeImage, 0, 0, 200, 100);
+	});
+
+	it("continues exporting strokes when the background image cannot be loaded", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const backgroundImage = "https://example.com/missing-bg.png";
+		MockImage.failingSources.add(backgroundImage);
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.innerHTML = `
+			<defs><pattern id="canvas__background"><image href="${backgroundImage}" /></pattern></defs>
+			<rect id="canvas__canvas-background" fill="url(#canvas__background)"></rect>
+			<g id="canvas__stroke-group-0"></g>
+		`;
+
+		await exportImageFromSvg({
+			id: "canvas",
+			svgCanvas: svg,
+			svgWidth: 200,
+			svgHeight: 100,
+			imageType: "png",
+			canvasColor: "white",
+			backgroundImage,
+			exportWithBackgroundImage: true,
+		});
+
+		const [strokeImage] = MockImage.instances;
+
+		expect(warn).toHaveBeenCalledWith(
+			"React Sketch Canvas could not load the background image while exporting. Check that backgroundImage points to a reachable image and allows cross-origin access.",
+		);
+		expect(drawImage).toHaveBeenCalledTimes(1);
+		expect(drawImage).toHaveBeenCalledWith(strokeImage, 0, 0, 200, 100);
+
+		warn.mockRestore();
 	});
 });

--- a/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
@@ -6,7 +6,26 @@ class MockImage {
 
 	static failingSources = new Set<string>();
 
-	public width = 100;
+	static dimensionsBySource = new Map<
+		string,
+		{ width: number; height: number }
+	>();
+
+	public get width() {
+		return MockImage.dimensionsBySource.get(this._src)?.width ?? 100;
+	}
+
+	public get height() {
+		return MockImage.dimensionsBySource.get(this._src)?.height ?? 100;
+	}
+
+	public get naturalWidth() {
+		return this.width;
+	}
+
+	public get naturalHeight() {
+		return this.height;
+	}
 
 	public onload: (() => void) | null = null;
 
@@ -71,6 +90,7 @@ describe("exportImageFromSvg", () => {
 	beforeEach(() => {
 		MockImage.instances = [];
 		MockImage.failingSources = new Set();
+		MockImage.dimensionsBySource = new Map();
 		drawImage.mockReset();
 		fillRect.mockReset();
 		globalThis.Image = MockImage as unknown as typeof Image;
@@ -155,7 +175,7 @@ describe("exportImageFromSvg", () => {
 		expect(drawImage).toHaveBeenNthCalledWith(2, strokeImage, 0, 0, 200, 100);
 	});
 
-	it("keeps data URL background images in the serialized SVG layer", async () => {
+	it("exports data URL background images as a separate raster layer", async () => {
 		const backgroundImage = "data:image/png;base64,bg";
 		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
 		svg.innerHTML = `
@@ -175,14 +195,63 @@ describe("exportImageFromSvg", () => {
 			exportWithBackgroundImage: true,
 		});
 
-		const [strokeImage] = MockImage.instances;
+		const [strokeImage, backgroundLayer] = MockImage.instances;
 		const serializedSvg = decodeSvgDataUri(strokeImage.src);
 
-		expect(MockImage.instances).toHaveLength(1);
-		expect(serializedSvg).toContain(backgroundImage);
-		expect(serializedSvg).toContain("__background");
-		expect(drawImage).toHaveBeenCalledTimes(1);
-		expect(drawImage).toHaveBeenCalledWith(strokeImage, 0, 0, 200, 100);
+		expect(MockImage.instances).toHaveLength(2);
+		expect(serializedSvg).not.toContain(backgroundImage);
+		expect(serializedSvg).not.toContain("__background");
+		expect(backgroundLayer.crossOrigin).toBeNull();
+		expect(backgroundLayer.src).toBe(backgroundImage);
+		expect(drawImage).toHaveBeenNthCalledWith(
+			1,
+			backgroundLayer,
+			0,
+			0,
+			200,
+			100,
+		);
+		expect(drawImage).toHaveBeenNthCalledWith(2, strokeImage, 0, 0, 200, 100);
+	});
+
+	it("draws raster background images with the configured SVG slice aspect ratio", async () => {
+		const backgroundImage = "https://example.com/wide-bg.png";
+		MockImage.dimensionsBySource.set(backgroundImage, {
+			width: 600,
+			height: 400,
+		});
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.innerHTML = `
+			<defs><pattern id="canvas__background"><image href="${backgroundImage}" /></pattern></defs>
+			<rect id="canvas__canvas-background" fill="url(#canvas__background)"></rect>
+			<g id="canvas__stroke-group-0"></g>
+		`;
+		await exportImageFromSvg({
+			id: "canvas",
+			svgCanvas: svg,
+			svgWidth: 200,
+			svgHeight: 100,
+			imageType: "png",
+			canvasColor: "white",
+			backgroundImage,
+			exportWithBackgroundImage: true,
+			preserveBackgroundImageAspectRatio: "xMidYMid slice",
+		});
+
+		const [, backgroundLayer] = MockImage.instances;
+
+		expect(drawImage).toHaveBeenNthCalledWith(
+			1,
+			backgroundLayer,
+			0,
+			50,
+			600,
+			300,
+			0,
+			0,
+			200,
+			100,
+		);
 	});
 
 	it("continues exporting strokes when the background image cannot be loaded", async () => {

--- a/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
@@ -80,6 +80,16 @@ function decodeSvgDataUri(dataUri: string) {
 	return atob(encodedSvg);
 }
 
+function decodeUrlEncodedSvgDataUri(dataUri: string) {
+	const [metadata = "", encodedSvg = ""] = dataUri.split(",");
+
+	if (metadata.includes(";base64")) {
+		return atob(encodedSvg);
+	}
+
+	return decodeURIComponent(encodedSvg);
+}
+
 describe("exportImageFromSvg", () => {
 	const originalImage = globalThis.Image;
 	const originalGetContext = HTMLCanvasElement.prototype.getContext;
@@ -251,6 +261,44 @@ describe("exportImageFromSvg", () => {
 			0,
 			200,
 			100,
+		);
+	});
+
+	it("renders SVG data URI backgrounds through the same SVG wrapper as the live canvas", async () => {
+		const backgroundImage =
+			"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 360'%3E%3Crect width='640' height='360' fill='white'/%3E%3C/svg%3E";
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.innerHTML = `
+			<defs><pattern id="canvas__background"><image href="${backgroundImage}" /></pattern></defs>
+			<rect id="canvas__canvas-background" fill="url(#canvas__background)"></rect>
+			<g id="canvas__stroke-group-0"></g>
+		`;
+		await exportImageFromSvg({
+			id: "canvas",
+			svgCanvas: svg,
+			svgWidth: 600,
+			svgHeight: 240,
+			imageType: "png",
+			canvasColor: "white",
+			backgroundImage,
+			exportWithBackgroundImage: true,
+			preserveBackgroundImageAspectRatio: "xMidYMid slice",
+		});
+
+		const [, backgroundLayer] = MockImage.instances;
+		const backgroundSvg = decodeUrlEncodedSvgDataUri(backgroundLayer.src);
+
+		expect(backgroundSvg).toContain('width="600"');
+		expect(backgroundSvg).toContain('height="240"');
+		expect(backgroundSvg).toContain(backgroundImage);
+		expect(backgroundSvg).toContain('preserveAspectRatio="xMidYMid slice"');
+		expect(drawImage).toHaveBeenNthCalledWith(
+			1,
+			backgroundLayer,
+			0,
+			0,
+			600,
+			240,
 		);
 	});
 

--- a/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { exportImageFromSvg } from "../../../src/Canvas/export/image";
+
+class MockImage {
+	static instances: MockImage[] = [];
+
+	public width = 100;
+
+	public onload: (() => void) | null = null;
+
+	public onerror: ((error: Error) => void) | null = null;
+
+	public attributes = new Map<string, string>();
+
+	private listeners = new Map<string, Array<() => void>>();
+
+	private _src = "";
+
+	public constructor() {
+		MockImage.instances.push(this);
+	}
+
+	public addEventListener(event: string, listener: () => void) {
+		const listeners = this.listeners.get(event) ?? [];
+		listeners.push(listener);
+		this.listeners.set(event, listeners);
+	}
+
+	public setAttribute(name: string, value: string) {
+		this.attributes.set(name, value);
+	}
+
+	public get src() {
+		return this._src;
+	}
+
+	public set src(value: string) {
+		this._src = value;
+		queueMicrotask(() => {
+			for (const listener of this.listeners.get("load") ?? []) {
+				listener();
+			}
+		});
+	}
+}
+
+function decodeSvgDataUri(dataUri: string) {
+	const [, encodedSvg = ""] = dataUri.split("base64,");
+	return atob(encodedSvg);
+}
+
+describe("exportImageFromSvg", () => {
+	const originalImage = globalThis.Image;
+	const originalGetContext = HTMLCanvasElement.prototype.getContext;
+	const originalToDataUrl = HTMLCanvasElement.prototype.toDataURL;
+	const drawImage = vi.fn();
+	const fillRect = vi.fn();
+
+	beforeEach(() => {
+		MockImage.instances = [];
+		drawImage.mockReset();
+		fillRect.mockReset();
+		globalThis.Image = MockImage as unknown as typeof Image;
+		HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+			drawImage,
+			fillRect,
+			fillStyle: "",
+		})) as typeof HTMLCanvasElement.prototype.getContext;
+		HTMLCanvasElement.prototype.toDataURL = vi.fn(
+			(type: string) => `data:${type};base64,export`,
+		);
+	});
+
+	afterEach(() => {
+		globalThis.Image = originalImage;
+		HTMLCanvasElement.prototype.getContext = originalGetContext;
+		HTMLCanvasElement.prototype.toDataURL = originalToDataUrl;
+	});
+
+	it("removes background-image markup from the serialized SVG when exporting without the background image", async () => {
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.innerHTML = `
+			<defs><pattern id="canvas__background"><image href="data:image/png;base64,bg" /></pattern></defs>
+			<rect id="canvas__canvas-background" fill="url(#canvas__background)"></rect>
+			<g id="canvas__stroke-group-0"></g>
+		`;
+
+		await exportImageFromSvg({
+			id: "canvas",
+			svgCanvas: svg,
+			svgWidth: 320,
+			svgHeight: 180,
+			imageType: "png",
+			canvasColor: "#abcdef",
+			backgroundImage: "data:image/png;base64,bg",
+			exportWithBackgroundImage: false,
+		});
+
+		const [strokeImage] = MockImage.instances;
+		const serializedSvg = decodeSvgDataUri(strokeImage.src);
+
+		expect(serializedSvg).not.toContain("canvas__background");
+		expect(serializedSvg).not.toContain("data:image/png;base64,bg");
+		expect(fillRect).toHaveBeenCalledWith(0, 0, 320, 180);
+		expect(MockImage.instances).toHaveLength(1);
+	});
+
+	it("exports the background image as a separate raster layer to avoid duplicate SVG artifacts", async () => {
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.innerHTML = `
+			<defs><pattern id="canvas__background"><image href="https://example.com/bg.png" /></pattern></defs>
+			<rect id="canvas__canvas-background" fill="url(#canvas__background)"></rect>
+			<g id="canvas__stroke-group-0"></g>
+		`;
+
+		await exportImageFromSvg({
+			id: "canvas",
+			svgCanvas: svg,
+			svgWidth: 200,
+			svgHeight: 100,
+			imageType: "jpeg",
+			canvasColor: "white",
+			backgroundImage: "https://example.com/bg.png",
+			exportWithBackgroundImage: true,
+		});
+
+		const [strokeImage, backgroundLayer] = MockImage.instances;
+		const serializedSvg = decodeSvgDataUri(strokeImage.src);
+
+		expect(serializedSvg).not.toContain("canvas__background");
+		expect(serializedSvg).not.toContain("https://example.com/bg.png");
+		expect(backgroundLayer.src).toBe("https://example.com/bg.png");
+		expect(drawImage).toHaveBeenNthCalledWith(
+			1,
+			backgroundLayer,
+			0,
+			0,
+			200,
+			100,
+		);
+		expect(drawImage).toHaveBeenNthCalledWith(2, strokeImage, 0, 0, 200, 100);
+	});
+});

--- a/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
@@ -94,8 +94,10 @@ describe("exportImageFromSvg", () => {
 	const originalImage = globalThis.Image;
 	const originalGetContext = HTMLCanvasElement.prototype.getContext;
 	const originalToDataUrl = HTMLCanvasElement.prototype.toDataURL;
+	const originalDevicePixelRatio = window.devicePixelRatio;
 	const drawImage = vi.fn();
 	const fillRect = vi.fn();
+	const scale = vi.fn();
 
 	beforeEach(() => {
 		MockImage.instances = [];
@@ -103,10 +105,12 @@ describe("exportImageFromSvg", () => {
 		MockImage.dimensionsBySource = new Map();
 		drawImage.mockReset();
 		fillRect.mockReset();
+		scale.mockReset();
 		globalThis.Image = MockImage as unknown as typeof Image;
 		HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
 			drawImage,
 			fillRect,
+			scale,
 			fillStyle: "",
 		})) as unknown as typeof HTMLCanvasElement.prototype.getContext;
 		HTMLCanvasElement.prototype.toDataURL = vi.fn(
@@ -118,6 +122,37 @@ describe("exportImageFromSvg", () => {
 		globalThis.Image = originalImage;
 		HTMLCanvasElement.prototype.getContext = originalGetContext;
 		HTMLCanvasElement.prototype.toDataURL = originalToDataUrl;
+		Object.defineProperty(window, "devicePixelRatio", {
+			configurable: true,
+			value: originalDevicePixelRatio,
+		});
+	});
+
+	it("uses rendered SVG dimensions for default raster export size", async () => {
+		Object.defineProperty(window, "devicePixelRatio", {
+			configurable: true,
+			value: 2,
+		});
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+
+		await exportImageFromSvg({
+			id: "canvas",
+			svgCanvas: svg,
+			svgWidth: 320,
+			svgHeight: 180,
+			imageType: "png",
+			canvasColor: "white",
+			backgroundImage: "",
+			exportWithBackgroundImage: false,
+		});
+
+		const canvas = vi.mocked(HTMLCanvasElement.prototype.toDataURL).mock
+			.contexts[0] as HTMLCanvasElement;
+
+		expect(canvas.width).toBe(320);
+		expect(canvas.height).toBe(180);
+		expect(canvas.style.width).toBe("320px");
+		expect(canvas.style.height).toBe("180px");
 	});
 
 	it("removes background-image markup from the serialized SVG when exporting without the background image", async () => {

--- a/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
@@ -14,6 +14,8 @@ class MockImage {
 
 	public attributes = new Map<string, string>();
 
+	public crossOrigin: string | null = null;
+
 	private listeners = new Map<string, Array<() => void>>();
 
 	private _src = "";
@@ -76,7 +78,7 @@ describe("exportImageFromSvg", () => {
 			drawImage,
 			fillRect,
 			fillStyle: "",
-		})) as typeof HTMLCanvasElement.prototype.getContext;
+		})) as unknown as typeof HTMLCanvasElement.prototype.getContext;
 		HTMLCanvasElement.prototype.toDataURL = vi.fn(
 			(type: string) => `data:${type};base64,export`,
 		);
@@ -140,6 +142,7 @@ describe("exportImageFromSvg", () => {
 
 		expect(serializedSvg).not.toContain("canvas__background");
 		expect(serializedSvg).not.toContain("https://example.com/bg.png");
+		expect(backgroundLayer.crossOrigin).toBe("anonymous");
 		expect(backgroundLayer.src).toBe("https://example.com/bg.png");
 		expect(drawImage).toHaveBeenNthCalledWith(
 			1,
@@ -150,6 +153,36 @@ describe("exportImageFromSvg", () => {
 			100,
 		);
 		expect(drawImage).toHaveBeenNthCalledWith(2, strokeImage, 0, 0, 200, 100);
+	});
+
+	it("keeps data URL background images in the serialized SVG layer", async () => {
+		const backgroundImage = "data:image/png;base64,bg";
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.innerHTML = `
+			<defs><pattern id="canvas__background"><image href="${backgroundImage}" /></pattern></defs>
+			<rect id="canvas__canvas-background" fill="url(#canvas__background)"></rect>
+			<g id="canvas__stroke-group-0"></g>
+		`;
+
+		await exportImageFromSvg({
+			id: "canvas",
+			svgCanvas: svg,
+			svgWidth: 200,
+			svgHeight: 100,
+			imageType: "png",
+			canvasColor: "white",
+			backgroundImage,
+			exportWithBackgroundImage: true,
+		});
+
+		const [strokeImage] = MockImage.instances;
+		const serializedSvg = decodeSvgDataUri(strokeImage.src);
+
+		expect(MockImage.instances).toHaveLength(1);
+		expect(serializedSvg).toContain(backgroundImage);
+		expect(serializedSvg).toContain("__background");
+		expect(drawImage).toHaveBeenCalledTimes(1);
+		expect(drawImage).toHaveBeenCalledWith(strokeImage, 0, 0, 200, 100);
 	});
 
 	it("continues exporting strokes when the background image cannot be loaded", async () => {

--- a/packages/react-sketch-canvas/tests/unit/canvas/svgExport.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/canvas/svgExport.spec.ts
@@ -27,13 +27,13 @@ describe("canvas SVG export helpers", () => {
 			<rect id="canvas__canvas-background" fill="url(#canvas__background)"></rect>
 		`;
 
-		prepareSvgForExport(svg, {
+		const exported = prepareSvgForExport(svg, {
 			id: "canvas",
 			canvasColor: "white",
 			exportWithBackgroundImage: true,
 		});
 
-		expect(svg.querySelector("#canvas__background")).not.toBeNull();
+		expect(exported.outerHTML).toContain("__background");
 	});
 
 	it("removes the background image pattern and restores canvas color when exporting without background image", () => {
@@ -43,15 +43,40 @@ describe("canvas SVG export helpers", () => {
 			<rect id="canvas__canvas-background" fill="url(#canvas__background)"></rect>
 		`;
 
-		prepareSvgForExport(svg, {
+		const exported = prepareSvgForExport(svg, {
 			id: "canvas",
 			canvasColor: "pink",
 			exportWithBackgroundImage: false,
 		});
 
-		expect(svg.querySelector("#canvas__background")).toBeNull();
-		expect(
-			svg.querySelector("#canvas__canvas-background")?.getAttribute("fill"),
-		).toBe("pink");
+		expect(exported.outerHTML).not.toContain('id="canvas__background"');
+		expect(exported.outerHTML).toContain('fill="pink"');
+	});
+
+	it("rewrites internal ids and references so exported SVG markup does not collide with the live canvas", () => {
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.innerHTML = `
+			<defs>
+				<pattern id="canvas__background"></pattern>
+				<mask id="canvas__eraser-mask-0">
+					<use href="#canvas__mask-background" xlink:href="#canvas__mask-background"></use>
+				</mask>
+			</defs>
+			<rect id="canvas__mask-background" fill="white"></rect>
+			<g id="canvas__stroke-group-0" mask="url(#canvas__eraser-mask-0)"></g>
+		`;
+
+		const exported = prepareSvgForExport(svg, {
+			id: "canvas",
+			canvasColor: "white",
+			exportWithBackgroundImage: true,
+		});
+		const output = exported.outerHTML;
+
+		expect(output).not.toContain('id="canvas__eraser-mask-0"');
+		expect(output).not.toContain('href="#canvas__mask-background"');
+		expect(output).not.toContain('mask="url(#canvas__eraser-mask-0)"');
+		expect(output).toMatch(/mask="url\(#canvas__export-[^"]+\)"/);
+		expect(output).toMatch(/href="#canvas__export-[^"]+"/);
 	});
 });

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/refStability.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/refStability.spec.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const receivedRefs: Array<React.ForwardedRef<unknown>> = [];
+
+vi.mock("../../../src/Canvas", () => ({
+	Canvas: React.forwardRef((_props, ref) => {
+		receivedRefs.push(ref);
+		return <div data-testid="canvas-stub" />;
+	}),
+}));
+
+describe("ReactSketchCanvas ref stability", () => {
+	beforeEach(() => {
+		receivedRefs.length = 0;
+		vi.resetModules();
+	});
+
+	it("reuses the same low-level canvas ref across rerenders", async () => {
+		const { ReactSketchCanvas } = await import(
+			"../../../src/ReactSketchCanvas"
+		);
+		const { rerender } = render(
+			<ReactSketchCanvas strokeColor="red" width="320px" height="180px" />,
+		);
+
+		rerender(
+			<ReactSketchCanvas strokeColor="blue" width="320px" height="180px" />,
+		);
+
+		expect(receivedRefs).toHaveLength(2);
+		expect(receivedRefs[0]).toBe(receivedRefs[1]);
+	});
+});


### PR DESCRIPTION
## Summary

- Fix raster exports so background images are composited consistently with the live SVG canvas.
- Keep default raster export dimensions tied to the rendered SVG size instead of implicitly scaling by device pixel ratio.
- Split raster export background loading, SVG encoding, and image loading into focused export helpers.
- Add regression coverage for SVG/background export behavior and ref stability.

## Root Cause

Raster export was relying on browser SVG rasterization for background images, which produced inconsistent behavior for data URI and external image backgrounds. A later cleanup also introduced implicit DPR scaling in the export canvas, which changed the documented default export-size contract.

## Issue Coverage

- Fixes #105: `exportWithBackgroundImage={false}` now strips background image markup before raster export and fills with `canvasColor`.
- Fixes #137: loadable background images are drawn as a separate raster layer before strokes, avoiding the broken SVG-rasterized background output.
- Fixes #142: exported SVG internal IDs are namespaced so exported markup cannot collide with the live canvas masks after export/clear/redraw.
- Fixes #145: default raster export size now matches the rendered SVG dimensions instead of implicit device-pixel-ratio scaling.
- Fixes #153: raster exports fill the canvas background when exporting without a background image or when exporting JPEG.
- Fixes #155: custom/data URI background images are exported as a dedicated background layer rather than duplicated inside the stroke SVG.
- Fixes #179: `ReactSketchCanvas` now keeps the low-level canvas ref stable across rerenders with `useRef`.

## Validation

- `pnpm --filter react-sketch-canvas lint`
- `pnpm --filter react-sketch-canvas test:unit -- tests/unit/canvas/imageExport.spec.ts tests/unit/canvas/svgExport.spec.ts tests/unit/react-sketch-canvas/refStability.spec.tsx`
- `pnpm --filter react-sketch-canvas test:ct -- tests/actions/export.spec.tsx`
- `pnpm --filter react-sketch-canvas build`
- Pre-commit hook: Biome check on staged files and full `pnpm --filter react-sketch-canvas test:unit`
