### PR TITLE
Add stroke eraser mode and isolate canvas masks

### DIFF
--- a/docs/app/styles.css
+++ b/docs/app/styles.css
@@ -123,6 +123,39 @@
 	accent-color: var(--color-fd-primary);
 }
 
+.example-preview :where(fieldset) {
+	display: inline-flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.5rem 0.875rem;
+	margin: 0;
+	border: 0;
+	padding: 0;
+}
+
+.example-preview :where(fieldset > legend) {
+	flex-basis: 100%;
+	margin-bottom: 0.5rem;
+	padding: 0;
+	font-size: 0.875rem;
+	font-weight: 500;
+	line-height: 1.25rem;
+	color: var(--color-fd-muted-foreground);
+}
+
+.example-preview :where(fieldset > label) {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.375rem;
+}
+
+.example-preview :where(input[type="radio"]) {
+	width: 1rem;
+	height: 1rem;
+	margin: 0;
+	accent-color: var(--color-fd-primary);
+}
+
 .example-preview :where(span) {
 	font-size: 0.875rem;
 	color: var(--color-fd-muted-foreground);

--- a/docs/src/components/HomePageDemo.tsx
+++ b/docs/src/components/HomePageDemo.tsx
@@ -1,15 +1,38 @@
-import { IconEraser, IconPencil, IconRestore } from "@tabler/icons-react";
+import {
+	IconArrowBackUp,
+	IconArrowForwardUp,
+	IconDownload,
+	IconEraser,
+	IconPencil,
+	IconRestore,
+	IconTrash,
+} from "@tabler/icons-react";
 import { type ChangeEvent, useEffect, useRef, useState } from "react";
 import {
+	type EraserMode,
 	ReactSketchCanvas,
 	type ReactSketchCanvasRef,
 } from "react-sketch-canvas";
 import paths from "../assets/initialSketch.json";
 
+const toolButtonClass =
+	"inline-flex h-8 min-w-0 flex-1 items-center justify-center gap-2 rounded-sm px-3 text-sm transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground aria-pressed:bg-fd-primary aria-pressed:text-fd-primary-foreground";
+
+const actionButtonClass =
+	"inline-flex h-9 items-center justify-center gap-2 rounded-md border bg-fd-background px-3 text-sm transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground";
+
+const rangeInputClass =
+	"h-2 w-full cursor-pointer accent-fd-primary disabled:cursor-not-allowed disabled:opacity-60";
+
 export function HomePageDemo() {
 	const [eraser, setEraser] = useState(false);
 	const ref = useRef<ReactSketchCanvasRef>(null);
 	const [strokeColor, setStrokeColor] = useState("#6497eb");
+	const [canvasColor, setCanvasColor] = useState("#ffffff");
+	const [strokeWidth, setStrokeWidth] = useState(4);
+	const [eraserWidth, setEraserWidth] = useState(14);
+	const [eraserMode, setEraserMode] = useState<EraserMode>("mask");
+	const [exportMessage, setExportMessage] = useState("PNG");
 
 	useEffect(() => {
 		if (ref.current) {
@@ -32,75 +55,247 @@ export function HomePageDemo() {
 	};
 
 	const handleResetClick = () => {
-		if (ref.current) {
-			ref.current.resetCanvas();
-		}
+		setEraser(false);
+		ref.current?.resetCanvas();
+		window.requestAnimationFrame(() => ref.current?.loadPaths(paths));
 	};
 
-	const onColorChange = (event: ChangeEvent<HTMLInputElement>) => {
+	const handleClearClick = () => {
+		ref.current?.clearCanvas();
+	};
+
+	const handleUndoClick = () => {
+		ref.current?.undo();
+	};
+
+	const handleRedoClick = () => {
+		ref.current?.redo();
+	};
+
+	const handleExportClick = async () => {
+		const image = await ref.current?.exportImage("png");
+
+		if (!image) {
+			return;
+		}
+
+		const anchor = document.createElement("a");
+		anchor.href = image;
+		anchor.download = "react-sketch-canvas-demo.png";
+		anchor.click();
+		setExportMessage("Saved");
+		window.setTimeout(() => setExportMessage("PNG"), 1600);
+	};
+
+	const onStrokeColorChange = (event: ChangeEvent<HTMLInputElement>) => {
 		setStrokeColor(event.target.value);
+	};
+
+	const onCanvasColorChange = (event: ChangeEvent<HTMLInputElement>) => {
+		setCanvasColor(event.target.value);
+	};
+
+	const onStrokeWidthChange = (event: ChangeEvent<HTMLInputElement>) => {
+		setStrokeWidth(Number(event.target.value));
+	};
+
+	const onEraserWidthChange = (event: ChangeEvent<HTMLInputElement>) => {
+		setEraserWidth(Number(event.target.value));
+	};
+
+	const handleEraserModeClick = (mode: EraserMode) => {
+		setEraserMode(mode);
 	};
 
 	return (
 		<div className="not-prose overflow-hidden rounded-xl border bg-fd-card shadow-sm">
-			<div className="bg-[linear-gradient(135deg,var(--color-fd-muted),transparent)] p-3">
-				<div className="overflow-hidden rounded-lg border bg-fd-background">
-					<ReactSketchCanvas
-						ref={ref}
-						canvasColor="transparent"
-						height="400px"
-						strokeWidth={4}
-						strokeColor={strokeColor}
-					/>
+			<div className="grid gap-0 bg-[linear-gradient(135deg,var(--color-fd-muted),transparent)] p-3 lg:grid-cols-[minmax(0,1fr)_18rem]">
+				<div className="overflow-hidden rounded-t-lg border bg-fd-background lg:rounded-r-none lg:rounded-bl-lg">
+					<div className="h-full">
+						<ReactSketchCanvas
+							ref={ref}
+							canvasColor={canvasColor}
+							eraserMode={eraserMode}
+							eraserWidth={eraserWidth}
+							height="100%"
+							strokeColor={strokeColor}
+							strokeWidth={strokeWidth}
+						/>
+					</div>
 				</div>
-			</div>
-			<div className="flex flex-wrap items-center gap-3 border-t bg-fd-muted/30 p-3">
-				<label
-					className="inline-flex h-9 items-center gap-2 rounded-md border bg-fd-background px-3 font-medium text-sm"
-					title="Ink color"
-				>
-					<span>Ink</span>
-					<input
-						aria-label="Ink color"
-						className="size-5 cursor-pointer rounded border bg-transparent p-0"
-						title="Ink color"
-						type="color"
-						value={strokeColor}
-						onChange={onColorChange}
-					/>
-				</label>
-				<fieldset className="flex items-center rounded-md border bg-fd-background p-0.5">
-					<legend className="sr-only">Drawing mode</legend>
-					<button
-						type="button"
-						aria-pressed={!eraser}
-						className="inline-flex h-8 items-center gap-2 rounded-sm px-3 text-sm transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground aria-pressed:bg-fd-primary aria-pressed:text-fd-primary-foreground"
-						title="Draw"
-						onClick={handlePencilClick}
-					>
-						<IconPencil aria-hidden="true" size={20} />
-						<span>Draw</span>
-					</button>
-					<button
-						type="button"
-						aria-pressed={eraser}
-						className="inline-flex h-8 items-center gap-2 rounded-sm px-3 text-sm transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground aria-pressed:bg-fd-primary aria-pressed:text-fd-primary-foreground"
-						title="Erase"
-						onClick={handleEraserClick}
-					>
-						<IconEraser aria-hidden="true" size={20} />
-						<span>Erase</span>
-					</button>
-				</fieldset>
-				<button
-					type="button"
-					className="inline-flex h-9 items-center gap-2 rounded-md border bg-fd-background px-3 text-sm transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
-					title="Reset"
-					onClick={handleResetClick}
-				>
-					<IconRestore aria-hidden="true" size={20} />
-					<span>Reset</span>
-				</button>
+				<div className="grid gap-4 rounded-b-lg border border-t-0 bg-fd-background p-3 lg:rounded-r-lg lg:rounded-bl-none lg:border-t lg:border-l-0">
+					<fieldset className="grid gap-2">
+						<legend className="mb-2 font-medium text-fd-muted-foreground text-xs uppercase">
+							Tool
+						</legend>
+						<div className="flex rounded-md border bg-fd-card p-0.5">
+							<button
+								type="button"
+								aria-pressed={!eraser}
+								className={toolButtonClass}
+								title="Draw"
+								onClick={handlePencilClick}
+							>
+								<IconPencil aria-hidden="true" size={18} />
+								<span>Pen</span>
+							</button>
+							<button
+								type="button"
+								aria-pressed={eraser}
+								className={toolButtonClass}
+								title="Erase"
+								onClick={handleEraserClick}
+							>
+								<IconEraser aria-hidden="true" size={18} />
+								<span>Eraser</span>
+							</button>
+						</div>
+					</fieldset>
+
+					<fieldset className="grid gap-2">
+						<legend className="mb-2 font-medium text-fd-muted-foreground text-xs uppercase">
+							Eraser mode
+						</legend>
+						<div className="grid grid-cols-2 rounded-md border bg-fd-card p-0.5">
+							<button
+								type="button"
+								aria-pressed={eraserMode === "mask"}
+								className="inline-flex h-8 items-center justify-center rounded-sm px-3 text-sm transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground aria-pressed:bg-fd-primary aria-pressed:text-fd-primary-foreground"
+								onClick={() => handleEraserModeClick("mask")}
+							>
+								<span>Mask</span>
+							</button>
+							<button
+								type="button"
+								aria-pressed={eraserMode === "stroke"}
+								className="inline-flex h-8 items-center justify-center rounded-sm px-3 text-sm transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground aria-pressed:bg-fd-primary aria-pressed:text-fd-primary-foreground"
+								onClick={() => handleEraserModeClick("stroke")}
+							>
+								<span>Stroke</span>
+							</button>
+						</div>
+					</fieldset>
+
+					<div className="grid gap-3">
+						<label className="grid gap-1.5 text-sm" htmlFor="home-stroke-width">
+							<span className="flex items-center justify-between">
+								<span className="font-medium">Stroke width</span>
+								<span className="text-fd-muted-foreground">
+									{strokeWidth}px
+								</span>
+							</span>
+							<input
+								className={rangeInputClass}
+								disabled={eraser}
+								id="home-stroke-width"
+								max="20"
+								min="1"
+								step="1"
+								type="range"
+								value={strokeWidth}
+								onChange={onStrokeWidthChange}
+							/>
+						</label>
+						<label className="grid gap-1.5 text-sm" htmlFor="home-eraser-width">
+							<span className="flex items-center justify-between">
+								<span className="font-medium">Eraser width</span>
+								<span className="text-fd-muted-foreground">
+									{eraserWidth}px
+								</span>
+							</span>
+							<input
+								className={rangeInputClass}
+								disabled={!eraser}
+								id="home-eraser-width"
+								max="40"
+								min="4"
+								step="1"
+								type="range"
+								value={eraserWidth}
+								onChange={onEraserWidthChange}
+							/>
+						</label>
+					</div>
+
+					<div className="grid grid-cols-2 gap-2">
+						<label
+							className="inline-flex h-10 items-center justify-between gap-2 rounded-md border bg-fd-card px-3 text-sm"
+							title="Ink color"
+						>
+							<span>Ink</span>
+							<input
+								aria-label="Ink color"
+								className="size-6 cursor-pointer rounded border bg-transparent p-0"
+								title="Ink color"
+								type="color"
+								value={strokeColor}
+								onChange={onStrokeColorChange}
+							/>
+						</label>
+						<label
+							className="inline-flex h-10 items-center justify-between gap-2 rounded-md border bg-fd-card px-3 text-sm"
+							title="Canvas color"
+						>
+							<span>Canvas</span>
+							<input
+								aria-label="Canvas color"
+								className="size-6 cursor-pointer rounded border bg-transparent p-0"
+								title="Canvas color"
+								type="color"
+								value={canvasColor}
+								onChange={onCanvasColorChange}
+							/>
+						</label>
+					</div>
+
+					<div className="grid grid-cols-2 gap-2">
+						<button
+							type="button"
+							className={actionButtonClass}
+							title="Undo"
+							onClick={handleUndoClick}
+						>
+							<IconArrowBackUp aria-hidden="true" size={18} />
+							<span>Undo</span>
+						</button>
+						<button
+							type="button"
+							className={actionButtonClass}
+							title="Redo"
+							onClick={handleRedoClick}
+						>
+							<IconArrowForwardUp aria-hidden="true" size={18} />
+							<span>Redo</span>
+						</button>
+						<button
+							type="button"
+							className={actionButtonClass}
+							title="Clear"
+							onClick={handleClearClick}
+						>
+							<IconTrash aria-hidden="true" size={18} />
+							<span>Clear</span>
+						</button>
+						<button
+							type="button"
+							className={actionButtonClass}
+							title="Reset"
+							onClick={handleResetClick}
+						>
+							<IconRestore aria-hidden="true" size={18} />
+							<span>Reset</span>
+						</button>
+						<button
+							type="button"
+							className={`${actionButtonClass} col-span-2`}
+							title="Export PNG"
+							onClick={handleExportClick}
+						>
+							<IconDownload aria-hidden="true" size={18} />
+							<span>Export {exportMessage}</span>
+						</button>
+					</div>
+				</div>
 			</div>
 		</div>
 	);

--- a/docs/src/content/docs/api/index.md
+++ b/docs/src/content/docs/api/index.md
@@ -18,6 +18,7 @@ title: "react-sketch-canvas"
 ## Type Aliases
 
 - [AllowOnlyPointerType](/api/type-aliases/allowonlypointertype/)
+- [EraserMode](/api/type-aliases/erasermode/)
 - [ExportImageType](/api/type-aliases/exportimagetype/)
 
 ## Variables

--- a/docs/src/content/docs/api/interfaces/canvasprops.md
+++ b/docs/src/content/docs/api/interfaces/canvasprops.md
@@ -133,13 +133,16 @@ Accepts any valid CSS height value, such as `"400px"`, `"60vh"`, or
 
 > `optional` **id?**: `string`
 
-Defined in: [Canvas/types.ts:140](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L140)
+Defined in: [Canvas/types.ts:143](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L143)
 
-Base DOM id used for the SVG canvas and generated SVG definitions.
+DOM id applied to the rendered SVG canvas.
 
 #### Remarks
 
-Use a unique id when rendering more than one canvas on the same page.
+Internal SVG definitions such as masks and background patterns are isolated
+per canvas instance, so multiple canvases can use the default id without
+sharing those internal references. Provide a unique id when application code
+needs to select or label a specific canvas element.
 
 #### Default Value
 
@@ -259,7 +262,7 @@ Paths rendered on the SVG canvas.
 
 > `optional` **preserveBackgroundImageAspectRatio?**: `string`
 
-Defined in: [Canvas/types.ts:150](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L150)
+Defined in: [Canvas/types.ts:153](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L153)
 
 SVG `preserveAspectRatio` value used for `backgroundImage`.
 
@@ -278,7 +281,7 @@ See the MDN reference for accepted values:
 
 > `optional` **readOnly?**: `boolean`
 
-Defined in: [Canvas/types.ts:196](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L196)
+Defined in: [Canvas/types.ts:199](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L199)
 
 Whether pointer drawing is disabled.
 
@@ -298,7 +301,7 @@ false
 
 > **style**: `CSSProperties`
 
-Defined in: [Canvas/types.ts:160](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L160)
+Defined in: [Canvas/types.ts:163](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L163)
 
 Inline styles applied to the outer canvas wrapper.
 
@@ -319,7 +322,7 @@ The package default canvas border style.
 
 > **svgStyle**: `CSSProperties`
 
-Defined in: [Canvas/types.ts:166](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L166)
+Defined in: [Canvas/types.ts:169](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L169)
 
 Inline styles applied to the internal SVG element.
 
@@ -333,7 +336,7 @@ Inline styles applied to the internal SVG element.
 
 > **width**: `string`
 
-Defined in: [Canvas/types.ts:187](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L187)
+Defined in: [Canvas/types.ts:190](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L190)
 
 CSS width of the canvas wrapper.
 
@@ -352,7 +355,7 @@ Accepts any valid CSS width value, such as `"600px"`, `"100%"`, or
 
 > `optional` **withViewBox?**: `boolean`
 
-Defined in: [Canvas/types.ts:177](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L177)
+Defined in: [Canvas/types.ts:180](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L180)
 
 Whether the internal SVG should include a viewBox based on the latest
 measured canvas size.

--- a/docs/src/content/docs/api/interfaces/canvasref.md
+++ b/docs/src/content/docs/api/interfaces/canvasref.md
@@ -5,7 +5,7 @@ prev: false
 title: "CanvasRef"
 ---
 
-Defined in: [Canvas/types.ts:204](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L204)
+Defined in: [Canvas/types.ts:207](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L207)
 
 Imperative ref API exposed by the low-level [Canvas](/api/variables/canvas/) component.
 
@@ -19,7 +19,7 @@ Imperative ref API exposed by the low-level [Canvas](/api/variables/canvas/) com
 
 > **exportImage**: (`imageType`, `options?`) => `Promise`\<`string`\>
 
-Defined in: [Canvas/types.ts:216](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L216)
+Defined in: [Canvas/types.ts:219](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L219)
 
 Export the current canvas as a raster image data URL.
 
@@ -54,7 +54,7 @@ depends on the `exportWithBackgroundImage` prop.
 
 > **exportSvg**: () => `Promise`\<`string`\>
 
-Defined in: [Canvas/types.ts:229](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L229)
+Defined in: [Canvas/types.ts:232](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L232)
 
 Export the current canvas as SVG markup.
 

--- a/docs/src/content/docs/api/interfaces/reactsketchcanvasprops.md
+++ b/docs/src/content/docs/api/interfaces/reactsketchcanvasprops.md
@@ -5,7 +5,7 @@ prev: false
 title: "ReactSketchCanvasProps"
 ---
 
-Defined in: [ReactSketchCanvas/types.ts:15](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L15)
+Defined in: [ReactSketchCanvas/types.ts:27](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L27)
 
 Props for the stateful [ReactSketchCanvas](/api/variables/reactsketchcanvas/) component.
 
@@ -110,11 +110,31 @@ CSS class name applied to the outer canvas wrapper.
 
 ***
 
+### eraserMode?
+
+> `optional` **eraserMode?**: [`EraserMode`](/api/type-aliases/erasermode/)
+
+Defined in: [ReactSketchCanvas/types.ts:54](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L54)
+
+Eraser behavior used when `eraseMode(true)` is active or a pen eraser
+button is detected.
+
+#### Remarks
+
+Use `"mask"` to preserve eraser gestures as SVG mask paths. Use `"stroke"`
+when erasing should delete whole drawing strokes touched by the eraser.
+
+#### Default Value
+
+`"mask"`
+
+***
+
 ### eraserWidth?
 
 > `optional` **eraserWidth?**: `number`
 
-Defined in: [ReactSketchCanvas/types.ts:31](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L31)
+Defined in: [ReactSketchCanvas/types.ts:43](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L43)
 
 Width of eraser strokes in pixels.
 
@@ -181,13 +201,16 @@ Accepts any valid CSS height value, such as `"400px"`, `"60vh"`, or
 
 > `optional` **id?**: `string`
 
-Defined in: [Canvas/types.ts:140](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L140)
+Defined in: [Canvas/types.ts:143](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L143)
 
-Base DOM id used for the SVG canvas and generated SVG definitions.
+DOM id applied to the rendered SVG canvas.
 
 #### Remarks
 
-Use a unique id when rendering more than one canvas on the same page.
+Internal SVG definitions such as masks and background patterns are isolated
+per canvas instance, so multiple canvases can use the default id without
+sharing those internal references. Provide a unique id when application code
+needs to select or label a specific canvas element.
 
 #### Default Value
 
@@ -203,7 +226,7 @@ Use a unique id when rendering more than one canvas on the same page.
 
 > `optional` **onChange?**: (`updatedPaths`) => `void`
 
-Defined in: [ReactSketchCanvas/types.ts:42](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L42)
+Defined in: [ReactSketchCanvas/types.ts:65](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L65)
 
 Called whenever the rendered path list changes.
 
@@ -232,7 +255,7 @@ invoked after strokes, undo, redo, clear, reset, and `loadPaths` updates.
 
 > `optional` **onStroke?**: (`path`, `isEraser`) => `void`
 
-Defined in: [ReactSketchCanvas/types.ts:55](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L55)
+Defined in: [ReactSketchCanvas/types.ts:78](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L78)
 
 Called when the user completes a stroke.
 
@@ -268,7 +291,7 @@ state.
 
 > `optional` **preserveBackgroundImageAspectRatio?**: `string`
 
-Defined in: [Canvas/types.ts:150](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L150)
+Defined in: [Canvas/types.ts:153](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L153)
 
 SVG `preserveAspectRatio` value used for `backgroundImage`.
 
@@ -291,7 +314,7 @@ See the MDN reference for accepted values:
 
 > `optional` **readOnly?**: `boolean`
 
-Defined in: [Canvas/types.ts:196](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L196)
+Defined in: [Canvas/types.ts:199](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L199)
 
 Whether pointer drawing is disabled.
 
@@ -315,7 +338,7 @@ false
 
 > `optional` **strokeColor?**: `string`
 
-Defined in: [ReactSketchCanvas/types.ts:65](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L65)
+Defined in: [ReactSketchCanvas/types.ts:88](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L88)
 
 Color used for drawing strokes.
 
@@ -336,7 +359,7 @@ RGB values, and CSS variables.
 
 > `optional` **strokeWidth?**: `number`
 
-Defined in: [ReactSketchCanvas/types.ts:74](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L74)
+Defined in: [ReactSketchCanvas/types.ts:97](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L97)
 
 Width of drawing strokes in pixels.
 
@@ -354,7 +377,7 @@ Eraser strokes use `eraserWidth` instead.
 
 > `optional` **style?**: `CSSProperties`
 
-Defined in: [Canvas/types.ts:160](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L160)
+Defined in: [Canvas/types.ts:163](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L163)
 
 Inline styles applied to the outer canvas wrapper.
 
@@ -379,7 +402,7 @@ The package default canvas border style.
 
 > `optional` **svgStyle?**: `CSSProperties`
 
-Defined in: [Canvas/types.ts:166](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L166)
+Defined in: [Canvas/types.ts:169](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L169)
 
 Inline styles applied to the internal SVG element.
 
@@ -397,7 +420,7 @@ Inline styles applied to the internal SVG element.
 
 > `optional` **width?**: `string`
 
-Defined in: [Canvas/types.ts:187](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L187)
+Defined in: [Canvas/types.ts:190](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L190)
 
 CSS width of the canvas wrapper.
 
@@ -420,7 +443,7 @@ Accepts any valid CSS width value, such as `"600px"`, `"100%"`, or
 
 > `optional` **withTimestamp?**: `boolean`
 
-Defined in: [ReactSketchCanvas/types.ts:85](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L85)
+Defined in: [ReactSketchCanvas/types.ts:108](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L108)
 
 Whether strokes should include start and end timestamps.
 
@@ -442,7 +465,7 @@ false
 
 > `optional` **withViewBox?**: `boolean`
 
-Defined in: [Canvas/types.ts:177](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L177)
+Defined in: [Canvas/types.ts:180](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L180)
 
 Whether the internal SVG should include a viewBox based on the latest
 measured canvas size.

--- a/docs/src/content/docs/api/interfaces/reactsketchcanvasref.md
+++ b/docs/src/content/docs/api/interfaces/reactsketchcanvasref.md
@@ -5,7 +5,7 @@ prev: false
 title: "ReactSketchCanvasRef"
 ---
 
-Defined in: [ReactSketchCanvas/types.ts:97](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L97)
+Defined in: [ReactSketchCanvas/types.ts:120](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L120)
 
 Imperative ref API exposed by [ReactSketchCanvas](/api/variables/reactsketchcanvas/).
 
@@ -24,7 +24,7 @@ from parent components.
 
 > **clearCanvas**: () => `void`
 
-Defined in: [ReactSketchCanvas/types.ts:119](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L119)
+Defined in: [ReactSketchCanvas/types.ts:142](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L142)
 
 Remove all paths from the canvas while preserving history.
 
@@ -46,7 +46,7 @@ history.
 
 > **eraseMode**: (`erase`) => `void`
 
-Defined in: [ReactSketchCanvas/types.ts:108](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L108)
+Defined in: [ReactSketchCanvas/types.ts:131](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L131)
 
 Switch between drawing and erasing.
 
@@ -75,7 +75,7 @@ to normal drawing mode. Existing paths are not changed.
 
 > **exportImage**: (`imageType`, `options?`) => `Promise`\<`string`\>
 
-Defined in: [Canvas/types.ts:216](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L216)
+Defined in: [Canvas/types.ts:219](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L219)
 
 Export the current canvas as a raster image data URL.
 
@@ -114,7 +114,7 @@ depends on the `exportWithBackgroundImage` prop.
 
 > **exportPaths**: () => `Promise`\<[`CanvasPath`](/api/interfaces/canvaspath/)[]\>
 
-Defined in: [ReactSketchCanvas/types.ts:148](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L148)
+Defined in: [ReactSketchCanvas/types.ts:171](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L171)
 
 Export the current path data.
 
@@ -134,7 +134,7 @@ The returned paths can be stored and later passed to `loadPaths()`.
 
 > **exportSvg**: () => `Promise`\<`string`\>
 
-Defined in: [Canvas/types.ts:229](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L229)
+Defined in: [Canvas/types.ts:232](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L232)
 
 Export the current canvas as SVG markup.
 
@@ -159,7 +159,7 @@ background handling has been applied.
 
 > **getSketchingTime**: () => `Promise`\<`number`\>
 
-Defined in: [ReactSketchCanvas/types.ts:169](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L169)
+Defined in: [ReactSketchCanvas/types.ts:192](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L192)
 
 Get the total active drawing time in milliseconds.
 
@@ -180,7 +180,7 @@ between strokes is not included.
 
 > **loadPaths**: (`paths`) => `void`
 
-Defined in: [ReactSketchCanvas/types.ts:159](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L159)
+Defined in: [ReactSketchCanvas/types.ts:182](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L182)
 
 Append paths to the canvas.
 
@@ -209,7 +209,7 @@ of the current path list and become part of undo/redo history.
 
 > **redo**: () => `void`
 
-Defined in: [ReactSketchCanvas/types.ts:139](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L139)
+Defined in: [ReactSketchCanvas/types.ts:162](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L162)
 
 Restore the next history entry after an undo.
 
@@ -230,7 +230,7 @@ unchanged.
 
 > **resetCanvas**: () => `void`
 
-Defined in: [ReactSketchCanvas/types.ts:179](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L179)
+Defined in: [ReactSketchCanvas/types.ts:202](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L202)
 
 Remove all paths and clear undo/redo history.
 
@@ -251,7 +251,7 @@ clearing action.
 
 > **undo**: () => `void`
 
-Defined in: [ReactSketchCanvas/types.ts:129](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L129)
+Defined in: [ReactSketchCanvas/types.ts:152](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L152)
 
 Restore the previous history entry.
 

--- a/docs/src/content/docs/api/type-aliases/erasermode.md
+++ b/docs/src/content/docs/api/type-aliases/erasermode.md
@@ -1,0 +1,18 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "EraserMode"
+---
+
+> **EraserMode** = `"mask"` \| `"stroke"`
+
+Defined in: [ReactSketchCanvas/types.ts:14](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts#L14)
+
+Eraser behavior used for pointer erasing.
+
+## Remarks
+
+`"mask"` stores eraser gestures as mask paths, preserving the historical
+export and undo/redo behavior. `"stroke"` removes whole drawing strokes
+touched by the eraser gesture instead of storing the gesture path.

--- a/docs/src/content/docs/api/type-aliases/meta.json
+++ b/docs/src/content/docs/api/type-aliases/meta.json
@@ -2,6 +2,7 @@
 	"title": "Type Aliases",
 	"pages": [
 		"allowonlypointertype",
+		"erasermode",
 		"exportimagetype"
 	]
 }

--- a/docs/src/content/docs/examples/drawing/index.mdx
+++ b/docs/src/content/docs/examples/drawing/index.mdx
@@ -16,6 +16,9 @@ Keep your UI state in sync with the canvas mode. That lets you show the selected
   <Card title="Color selection" icon="pencil" href="/examples/drawing/color-selection/">
     Pass `strokeColor` and `canvasColor` from your own controls.
   </Card>
+  <Card title="Dark and light mode" icon="sun-moon" href="/examples/drawing/theme-colors/">
+    Use custom CSS variables to adapt canvas colors to the user&apos;s color scheme.
+  </Card>
   <Card title="Read-only mode" icon="signature" href="/examples/drawing/read-only/">
     Render saved drawings without accepting new pointer input.
   </Card>

--- a/docs/src/content/docs/examples/drawing/meta.json
+++ b/docs/src/content/docs/examples/drawing/meta.json
@@ -1,4 +1,4 @@
 {
 	"title": "Drawing & Erasing",
-	"pages": ["switching-modes", "color-selection", "read-only"]
+	"pages": ["switching-modes", "color-selection", "theme-colors", "read-only"]
 }

--- a/docs/src/content/docs/examples/drawing/switching-modes.mdx
+++ b/docs/src/content/docs/examples/drawing/switching-modes.mdx
@@ -11,25 +11,40 @@ Most drawing tools need at least two modes: adding ink and removing it. `ReactSk
 
 Keep your UI state in sync with the canvas mode. That lets you show the selected tool, expose the right width control, and avoid confusing users about what the next stroke will do.
 
+The default `eraserMode="mask"` keeps eraser gestures as mask paths, which preserves the existing SVG-style erase behavior. Use `eraserMode="stroke"` when the eraser should delete each drawing stroke it touches instead of storing an eraser path.
+
 <ExampleBlock source={DrawingSource}>
   <Drawing />
 </ExampleBlock>
 
 ```tsx twoslash title="Erase mode"
 import React from "react";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import {
   ReactSketchCanvas,
+  type EraserMode,
   type ReactSketchCanvasRef,
 } from "react-sketch-canvas";
 
 export function DrawingToolbar() {
   const canvasRef = useRef<ReactSketchCanvasRef>(null);
+  const [eraserMode, setEraserMode] = useState<EraserMode>("mask");
 
   return (
-    <button type="button" onClick={() => canvasRef.current?.eraseMode(true)}>
-      Erase
-    </button>
+    <>
+      <ReactSketchCanvas ref={canvasRef} eraserMode={eraserMode} />
+      <button type="button" onClick={() => canvasRef.current?.eraseMode(true)}>
+        Erase
+      </button>
+      <select
+        aria-label="Eraser mode"
+        value={eraserMode}
+        onChange={(event) => setEraserMode(event.target.value as EraserMode)}
+      >
+        <option value="mask">Mask</option>
+        <option value="stroke">Stroke</option>
+      </select>
+    </>
   );
 }
 ```

--- a/docs/src/content/docs/examples/drawing/theme-colors.mdx
+++ b/docs/src/content/docs/examples/drawing/theme-colors.mdx
@@ -1,0 +1,16 @@
+---
+title: Dark and light mode
+description: Use custom CSS to adapt canvas colors to the user's color scheme.
+---
+
+import ExampleBlock from "../../../../components/ExampleBlock";
+import ThemeColors from "../../../../examples/ThemeColors";
+import ThemeColorsSource from "../../../../examples/ThemeColors.tsx?raw";
+
+`ReactSketchCanvas` does not switch colors automatically when the user's system theme changes. Keep theme state in your own app, or use CSS variables that respond to `prefers-color-scheme`.
+
+Pass those variables to `canvasColor` and `strokeColor` so the canvas uses the same theme tokens as the surrounding UI. This example toggles a `data-theme` attribute, and the CSS also shows how to fall back to the user's system color scheme.
+
+<ExampleBlock source={ThemeColorsSource}>
+  <ThemeColors />
+</ExampleBlock>

--- a/docs/src/examples/Drawing.tsx
+++ b/docs/src/examples/Drawing.tsx
@@ -1,5 +1,6 @@
 import { type ChangeEvent, useRef, useState } from "react";
 import {
+	type EraserMode,
 	ReactSketchCanvas,
 	type ReactSketchCanvasRef,
 } from "react-sketch-canvas";
@@ -7,6 +8,7 @@ import {
 export default function App() {
 	const canvasRef = useRef<ReactSketchCanvasRef>(null);
 	const [eraseMode, setEraseMode] = useState(false);
+	const [eraserMode, setEraserMode] = useState<EraserMode>("mask");
 	const [strokeWidth, setStrokeWidth] = useState(5);
 	const [eraserWidth, setEraserWidth] = useState(10);
 
@@ -26,6 +28,10 @@ export default function App() {
 
 	const handleEraserWidthChange = (event: ChangeEvent<HTMLInputElement>) => {
 		setEraserWidth(+event.target.value);
+	};
+
+	const handleEraserModeChange = (event: ChangeEvent<HTMLInputElement>) => {
+		setEraserMode(event.target.value as EraserMode);
 	};
 
 	return (
@@ -60,10 +66,34 @@ export default function App() {
 					value={eraserWidth}
 					onChange={handleEraserWidthChange}
 				/>
+				<fieldset>
+					<legend>Eraser mode</legend>
+					<label>
+						<input
+							type="radio"
+							name="eraserMode"
+							value="mask"
+							checked={eraserMode === "mask"}
+							onChange={handleEraserModeChange}
+						/>
+						Mask
+					</label>
+					<label>
+						<input
+							type="radio"
+							name="eraserMode"
+							value="stroke"
+							checked={eraserMode === "stroke"}
+							onChange={handleEraserModeChange}
+						/>
+						Stroke
+					</label>
+				</fieldset>
 			</div>
 			<h1>Canvas</h1>
 			<ReactSketchCanvas
 				ref={canvasRef}
+				eraserMode={eraserMode}
 				strokeWidth={strokeWidth}
 				eraserWidth={eraserWidth}
 			/>

--- a/docs/src/examples/ThemeColors.tsx
+++ b/docs/src/examples/ThemeColors.tsx
@@ -1,0 +1,239 @@
+import { type ChangeEvent, useRef, useState } from "react";
+import {
+	type EraserMode,
+	ReactSketchCanvas,
+	type ReactSketchCanvasRef,
+} from "react-sketch-canvas";
+
+type Theme = "light" | "dark";
+
+export default function App() {
+	const canvasRef = useRef<ReactSketchCanvasRef>(null);
+	const [theme, setTheme] = useState<Theme>("light");
+	const [eraseMode, setEraseMode] = useState(false);
+	const [eraserMode, setEraserMode] = useState<EraserMode>("mask");
+	const [strokeWidth, setStrokeWidth] = useState(5);
+	const [eraserWidth, setEraserWidth] = useState(10);
+
+	const handlePenClick = () => {
+		setEraseMode(false);
+		canvasRef.current?.eraseMode(false);
+	};
+
+	const handleEraserClick = () => {
+		setEraseMode(true);
+		canvasRef.current?.eraseMode(true);
+	};
+
+	const handleStrokeWidthChange = (event: ChangeEvent<HTMLInputElement>) => {
+		setStrokeWidth(+event.target.value);
+	};
+
+	const handleEraserWidthChange = (event: ChangeEvent<HTMLInputElement>) => {
+		setEraserWidth(+event.target.value);
+	};
+
+	const handleEraserModeChange = (event: ChangeEvent<HTMLInputElement>) => {
+		setEraserMode(event.target.value as EraserMode);
+	};
+
+	return (
+		<section className="rsc-theme-example" data-theme={theme}>
+			<style>
+				{`
+					.rsc-theme-example {
+						--rsc-theme-border: #cbd5e1;
+						--rsc-theme-canvas: #ffffff;
+						--rsc-theme-stroke: #2563eb;
+					}
+
+					.rsc-theme-example[data-theme="dark"] {
+						--rsc-theme-border: #334155;
+						--rsc-theme-canvas: #020617;
+						--rsc-theme-stroke: #38bdf8;
+					}
+
+					.rsc-theme-example__surface {
+						border: 1px solid var(--rsc-theme-border);
+						padding: 1rem;
+					}
+
+					.rsc-theme-example__tools {
+						border: 1px solid #d4d4d8;
+						background: #fafafa;
+						display: grid;
+						gap: 1rem;
+						grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+						margin-block-end: 1rem;
+						padding: 1rem;
+					}
+
+					.rsc-theme-example__tool-group {
+						border: 0;
+						display: grid;
+						gap: 0.5rem;
+						margin: 0;
+						min-inline-size: 0;
+						padding: 0;
+					}
+
+					.rsc-theme-example__tool-group legend,
+					.rsc-theme-example__range-control span {
+						color: #52525b;
+						font-size: 0.875rem;
+						font-weight: 600;
+						padding: 0;
+					}
+
+					.rsc-theme-example__button-row,
+					.rsc-theme-example__radio-row {
+						display: flex;
+						flex-wrap: wrap;
+						gap: 0.5rem;
+					}
+
+					.rsc-theme-example__radio-row label {
+						display: flex;
+						align-items: center;
+						gap: 0.25rem;
+					}
+
+					.rsc-theme-example__range-control {
+						display: grid;
+						gap: 0.375rem;
+					}
+
+					.rsc-theme-example__range-control input {
+						width: 100%;
+					}
+
+					@media (prefers-color-scheme: dark) {
+						.rsc-theme-example {
+							--rsc-theme-border: #334155;
+							--rsc-theme-canvas: #020617;
+							--rsc-theme-stroke: #38bdf8;
+						}
+					}
+				`}
+			</style>
+
+			<h1>Tools</h1>
+			<div className="rsc-theme-example__tools">
+				<fieldset className="rsc-theme-example__tool-group">
+					<legend>Canvas theme</legend>
+					<div className="rsc-theme-example__button-row">
+						<button
+							type="button"
+							disabled={theme === "light"}
+							onClick={() => setTheme("light")}
+						>
+							Light
+						</button>
+						<button
+							type="button"
+							disabled={theme === "dark"}
+							onClick={() => setTheme("dark")}
+						>
+							Dark
+						</button>
+					</div>
+				</fieldset>
+
+				<fieldset className="rsc-theme-example__tool-group">
+					<legend>Mode</legend>
+					<div className="rsc-theme-example__button-row">
+						<button
+							type="button"
+							disabled={!eraseMode}
+							onClick={handlePenClick}
+						>
+							Pen
+						</button>
+						<button
+							type="button"
+							disabled={eraseMode}
+							onClick={handleEraserClick}
+						>
+							Eraser
+						</button>
+					</div>
+				</fieldset>
+
+				<div className="rsc-theme-example__tool-group">
+					<label
+						className="rsc-theme-example__range-control"
+						htmlFor="strokeWidth"
+					>
+						<span>Stroke width</span>
+						<input
+							disabled={eraseMode}
+							type="range"
+							min="1"
+							max="20"
+							step="1"
+							id="strokeWidth"
+							value={strokeWidth}
+							onChange={handleStrokeWidthChange}
+						/>
+					</label>
+					<label
+						className="rsc-theme-example__range-control"
+						htmlFor="eraserWidth"
+					>
+						<span>Eraser width</span>
+						<input
+							disabled={!eraseMode}
+							type="range"
+							min="1"
+							max="20"
+							step="1"
+							id="eraserWidth"
+							value={eraserWidth}
+							onChange={handleEraserWidthChange}
+						/>
+					</label>
+				</div>
+
+				<fieldset className="rsc-theme-example__tool-group">
+					<legend>Eraser mode</legend>
+					<div className="rsc-theme-example__radio-row">
+						<label>
+							<input
+								type="radio"
+								name="eraserMode"
+								value="mask"
+								checked={eraserMode === "mask"}
+								onChange={handleEraserModeChange}
+							/>
+							Mask
+						</label>
+						<label>
+							<input
+								type="radio"
+								name="eraserMode"
+								value="stroke"
+								checked={eraserMode === "stroke"}
+								onChange={handleEraserModeChange}
+							/>
+							Stroke
+						</label>
+					</div>
+				</fieldset>
+			</div>
+
+			<h1>Canvas</h1>
+			<div className="rsc-theme-example__surface">
+				<ReactSketchCanvas
+					ref={canvasRef}
+					width="100%"
+					height="220px"
+					canvasColor="var(--rsc-theme-canvas)"
+					strokeColor="var(--rsc-theme-stroke)"
+					eraserMode={eraserMode}
+					strokeWidth={strokeWidth}
+					eraserWidth={eraserWidth}
+				/>
+			</div>
+		</section>
+	);
+}

--- a/packages/react-sketch-canvas/playwright/e2e/canvas.spec.ts
+++ b/packages/react-sketch-canvas/playwright/e2e/canvas.spec.ts
@@ -107,19 +107,25 @@ test("supports eraser mode with undo and redo controls", async ({ page }) => {
 	await drawLine(canvas, { length: 30, originX: 20, originY: 20 });
 
 	await expect(page.locator("#path-count")).toHaveText("2");
-	await expect(canvas.locator("#rsc__eraser-stroke-group path")).toHaveCount(1);
+	await expect(
+		canvas.locator('[id$="__eraser-stroke-group"] path'),
+	).toHaveCount(1);
 
 	await page.locator("#undo-button").click();
 	await expect(page.locator("#path-count")).toHaveText("1");
-	await expect(canvas.locator("#rsc__eraser-stroke-group path")).toHaveCount(0);
+	await expect(
+		canvas.locator('[id$="__eraser-stroke-group"] path'),
+	).toHaveCount(0);
 
 	await page.locator("#redo-button").click();
 	await expect(page.locator("#path-count")).toHaveText("2");
-	await expect(canvas.locator("#rsc__eraser-stroke-group path")).toHaveCount(1);
+	await expect(
+		canvas.locator('[id$="__eraser-stroke-group"] path'),
+	).toHaveCount(1);
 
 	await page.locator("#export-svg-button").click();
 	await expect(page.locator("#exported-svg")).toContainText(
-		/rsc__export-\d+__eraser-0/,
+		/rsc__export-\d+.*__eraser-0/,
 	);
 	await expect(page.locator("#exported-svg")).not.toContainText("undefined");
 });
@@ -134,7 +140,9 @@ test("renders erased pixels as canvas background in Firefox-compatible SVG masks
 	await page.locator("#eraser-button").click();
 	await drawLine(canvas, { length: 30, originX: 20, originY: 20 });
 
-	await expect(canvas.locator("#rsc__eraser-stroke-group path")).toHaveCount(1);
+	await expect(
+		canvas.locator('[id$="__eraser-stroke-group"] path'),
+	).toHaveCount(1);
 
 	const erasedPixel = await getSvgPixel(page, "#rsc", 30, 30);
 

--- a/packages/react-sketch-canvas/src/Canvas/export/svg.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/svg.ts
@@ -14,6 +14,13 @@ type PrepareSvgForExportReturns = SVGElement;
 
 let svgExportNonce = 0;
 
+function queryInternalElement(
+	svgCanvas: SVGElement,
+	suffix: string,
+): Element | null {
+	return svgCanvas.querySelector(`[id$="__${suffix}"]`);
+}
+
 /**
  * Rewrite exported SVG ids so the serialized markup can coexist with the live canvas.
  *
@@ -86,9 +93,10 @@ export function removeBackgroundImageFromSvg(
 	svgCanvas: SVGElement,
 	id: string,
 ): SVGElement {
-	svgCanvas.querySelector(`#${id}__background`)?.remove();
-	svgCanvas.querySelector(`#${id}__canvas-background-group`)?.remove();
-	svgCanvas.querySelector(`#${id}__canvas-background`)?.remove();
+	void id;
+	queryInternalElement(svgCanvas, "background")?.remove();
+	queryInternalElement(svgCanvas, "canvas-background-group")?.remove();
+	queryInternalElement(svgCanvas, "canvas-background")?.remove();
 
 	return svgCanvas;
 }
@@ -106,10 +114,11 @@ export function prepareSvgForExport(
 	{ id, canvasColor, exportWithBackgroundImage }: PrepareSvgForExportArgs,
 ): PrepareSvgForExportReturns {
 	if (!exportWithBackgroundImage) {
-		svgCanvas.querySelector(`#${id}__background`)?.remove();
-		svgCanvas
-			.querySelector(`#${id}__canvas-background`)
-			?.setAttribute("fill", canvasColor);
+		queryInternalElement(svgCanvas, "background")?.remove();
+		queryInternalElement(svgCanvas, "canvas-background")?.setAttribute(
+			"fill",
+			canvasColor,
+		);
 	}
 
 	namespaceSvgInternalIds(svgCanvas, id);

--- a/packages/react-sketch-canvas/src/Canvas/index.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/index.tsx
@@ -51,6 +51,11 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 		width: number;
 		height: number;
 	} | null>(null);
+	const reactId = React.useId();
+	const internalId = React.useMemo(
+		() => `${id}__${reactId.replaceAll(":", "")}`,
+		[id, reactId],
+	);
 
 	useCanvasExportHandle(ref, {
 		canvasRef,
@@ -94,6 +99,7 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 		>
 			<CanvasSvg
 				id={id}
+				internalId={internalId}
 				paths={paths}
 				canvasColor={canvasColor}
 				backgroundImage={backgroundImage}

--- a/packages/react-sketch-canvas/src/Canvas/svg/Background.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/Background.tsx
@@ -1,11 +1,12 @@
 import type * as React from "react";
 import type { CanvasProps } from "../types";
 
-type BackgroundProps = Required<Pick<CanvasProps, "id">> &
-	Pick<
-		CanvasProps,
-		"backgroundImage" | "canvasColor" | "preserveBackgroundImageAspectRatio"
-	>;
+type BackgroundProps = Pick<
+	CanvasProps,
+	"backgroundImage" | "canvasColor" | "preserveBackgroundImageAspectRatio"
+> & {
+	internalId: string;
+};
 
 /**
  * Defines the SVG pattern used to paint a configured background image.
@@ -15,18 +16,18 @@ type BackgroundProps = Required<Pick<CanvasProps, "id">> &
  * rectangle decides whether to reference this pattern or use `canvasColor`.
  */
 export function BackgroundPattern({
-	id,
+	internalId,
 	backgroundImage,
 	preserveBackgroundImageAspectRatio,
 }: Pick<
 	BackgroundProps,
-	"id" | "backgroundImage" | "preserveBackgroundImageAspectRatio"
+	"internalId" | "backgroundImage" | "preserveBackgroundImageAspectRatio"
 >): React.JSX.Element | null {
 	if (!backgroundImage) return null;
 
 	return (
 		<pattern
-			id={`${id}__background`}
+			id={`${internalId}__background`}
 			x="0"
 			y="0"
 			width="100%"
@@ -53,22 +54,22 @@ export function BackgroundPattern({
  * the background when producing SVG output.
  */
 export function BackgroundRect({
-	id,
+	internalId,
 	backgroundImage,
 	canvasColor,
 }: Pick<
 	BackgroundProps,
-	"id" | "backgroundImage" | "canvasColor"
+	"internalId" | "backgroundImage" | "canvasColor"
 >): React.JSX.Element {
 	return (
-		<g id={`${id}__canvas-background-group`}>
+		<g id={`${internalId}__canvas-background-group`}>
 			<rect
-				id={`${id}__canvas-background`}
+				id={`${internalId}__canvas-background`}
 				x="0"
 				y="0"
 				width="100%"
 				height="100%"
-				fill={backgroundImage ? `url(#${id}__background)` : canvasColor}
+				fill={backgroundImage ? `url(#${internalId}__background)` : canvasColor}
 			/>
 		</g>
 	);

--- a/packages/react-sketch-canvas/src/Canvas/svg/CanvasSvg.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/CanvasSvg.tsx
@@ -14,6 +14,7 @@ type CanvasSvgProps = Required<Pick<CanvasProps, "id">> &
 		| "preserveBackgroundImageAspectRatio"
 		| "svgStyle"
 	> & {
+		internalId: string;
 		viewBox?: string;
 	};
 
@@ -27,6 +28,7 @@ type CanvasSvgProps = Required<Pick<CanvasProps, "id">> &
  */
 export function CanvasSvg({
 	id,
+	internalId,
 	paths,
 	canvasColor,
 	backgroundImage,
@@ -53,22 +55,29 @@ export function CanvasSvg({
 			viewBox={viewBox}
 		>
 			<defs>
-				<HiddenEraserStrokes id={id} eraserPaths={eraserPaths} />
+				<HiddenEraserStrokes
+					internalId={internalId}
+					eraserPaths={eraserPaths}
+				/>
 				<BackgroundPattern
-					id={id}
+					internalId={internalId}
 					backgroundImage={backgroundImage}
 					preserveBackgroundImageAspectRatio={
 						preserveBackgroundImageAspectRatio
 					}
 				/>
-				<EraserMaskDefs id={id} eraserPaths={eraserPaths} />
+				<EraserMaskDefs internalId={internalId} eraserPaths={eraserPaths} />
 			</defs>
 			<BackgroundRect
-				id={id}
+				internalId={internalId}
 				backgroundImage={backgroundImage}
 				canvasColor={canvasColor}
 			/>
-			<StrokeGroups id={id} pathGroups={pathGroups} eraserPaths={eraserPaths} />
+			<StrokeGroups
+				internalId={internalId}
+				pathGroups={pathGroups}
+				eraserPaths={eraserPaths}
+			/>
 		</svg>
 	);
 }

--- a/packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx
@@ -1,9 +1,9 @@
 import type * as React from "react";
 import { SvgPath } from "../../Paths";
 import type { CanvasPath } from "../../types";
-import type { CanvasProps } from "../types";
 
-type EraserMasksProps = Required<Pick<CanvasProps, "id">> & {
+type EraserMasksProps = {
+	internalId: string;
 	eraserPaths: CanvasPath[];
 };
 
@@ -16,26 +16,26 @@ type EraserMasksProps = Required<Pick<CanvasProps, "id">> & {
  * it in path order.
  */
 export function HiddenEraserStrokes({
-	id,
+	internalId,
 	eraserPaths,
 }: EraserMasksProps): React.JSX.Element {
 	return (
-		<g id={`${id}__eraser-stroke-group`}>
+		<g id={`${internalId}__eraser-stroke-group`}>
 			<rect
-				id={`${id}__mask-background`}
+				id={`${internalId}__mask-background`}
 				x="0"
 				y="0"
 				width="100%"
 				height="100%"
-				fill="white"
+				fill="#fff"
 			/>
 			{eraserPaths.map((eraserPath, i) => (
 				<SvgPath
 					// biome-ignore lint/suspicious/noArrayIndexKey: eraser masks are generated from ordered strokes with no domain id.
-					key={`${id}__eraser-${i}`}
-					id={`${id}__eraser-${i}`}
+					key={`${internalId}__eraser-${i}`}
+					id={`${internalId}__eraser-${i}`}
 					paths={eraserPath.paths}
-					strokeColor="#000000"
+					strokeColor="#000"
 					strokeWidth={eraserPath.strokeWidth}
 				/>
 			))}
@@ -52,28 +52,31 @@ export function HiddenEraserStrokes({
  * created after that drawing group.
  */
 export function EraserMaskDefs({
-	id,
+	internalId,
 	eraserPaths,
 }: EraserMasksProps): React.JSX.Element {
 	return (
 		<>
 			{eraserPaths.map((_, i) => (
 				<mask
-					id={`${id}__eraser-mask-${i}`}
+					id={`${internalId}__eraser-mask-${i}`}
 					// biome-ignore lint/suspicious/noArrayIndexKey: mask order is tied to ordered eraser strokes.
-					key={`${id}__eraser-mask-${i}`}
+					key={`${internalId}__eraser-mask-${i}`}
+					className="react-sketch-canvas__eraser-mask darkreader-ignore"
+					data-darkreader-ignore=""
 					maskUnits="userSpaceOnUse"
+					style={{ colorScheme: "light" }}
 				>
 					<use
-						href={`#${id}__mask-background`}
-						xlinkHref={`#${id}__mask-background`}
+						href={`#${internalId}__mask-background`}
+						xlinkHref={`#${internalId}__mask-background`}
 					/>
 					{Array.from({ length: eraserPaths.length - i }, (_i, j) => j + i).map(
 						(k) => (
 							<use
 								key={k.toString()}
-								href={`#${id}__eraser-${k.toString()}`}
-								xlinkHref={`#${id}__eraser-${k.toString()}`}
+								href={`#${internalId}__eraser-${k.toString()}`}
+								xlinkHref={`#${internalId}__eraser-${k.toString()}`}
 							/>
 						),
 					)}

--- a/packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx
@@ -27,7 +27,7 @@ export function HiddenEraserStrokes({
 				y="0"
 				width="100%"
 				height="100%"
-				fill="#fff"
+				fill="white"
 			/>
 			{eraserPaths.map((eraserPath, i) => (
 				<SvgPath
@@ -62,10 +62,7 @@ export function EraserMaskDefs({
 					id={`${internalId}__eraser-mask-${i}`}
 					// biome-ignore lint/suspicious/noArrayIndexKey: mask order is tied to ordered eraser strokes.
 					key={`${internalId}__eraser-mask-${i}`}
-					className="react-sketch-canvas__eraser-mask darkreader-ignore"
-					data-darkreader-ignore=""
 					maskUnits="userSpaceOnUse"
-					style={{ colorScheme: "light" }}
 				>
 					<use
 						href={`#${internalId}__mask-background`}

--- a/packages/react-sketch-canvas/src/Canvas/svg/StrokeGroups.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/StrokeGroups.tsx
@@ -1,9 +1,9 @@
 import type * as React from "react";
 import Paths from "../../Paths";
 import type { CanvasPath } from "../../types";
-import type { CanvasProps } from "../types";
 
-type StrokeGroupsProps = Required<Pick<CanvasProps, "id">> & {
+type StrokeGroupsProps = {
+	internalId: string;
 	pathGroups: CanvasPath[][];
 	eraserPaths: CanvasPath[];
 };
@@ -17,7 +17,7 @@ type StrokeGroupsProps = Required<Pick<CanvasProps, "id">> & {
  * erasing without mutating existing path data.
  */
 export function StrokeGroups({
-	id,
+	internalId,
 	pathGroups,
 	eraserPaths,
 }: StrokeGroupsProps): React.JSX.Element {
@@ -26,11 +26,16 @@ export function StrokeGroups({
 			{pathGroups.map((pathGroup, i) => (
 				<g
 					// biome-ignore lint/suspicious/noArrayIndexKey: stroke groups are ordered drawing segments with no domain id.
-					key={`${id}__stroke-group-${i}`}
-					id={`${id}__stroke-group-${i}`}
-					{...(eraserPaths[i] ? { mask: `url(#${id}__eraser-mask-${i})` } : {})}
+					key={`${internalId}__stroke-group-${i}`}
+					id={`${internalId}__stroke-group-${i}`}
+					{...(eraserPaths[i]
+						? { mask: `url(#${internalId}__eraser-mask-${i})` }
+						: {})}
 				>
-					<Paths id={`${id}__stroke-group-${i}__paths`} paths={pathGroup} />
+					<Paths
+						id={`${internalId}__stroke-group-${i}__paths`}
+						paths={pathGroup}
+					/>
 				</g>
 			))}
 		</>

--- a/packages/react-sketch-canvas/src/Canvas/types.ts
+++ b/packages/react-sketch-canvas/src/Canvas/types.ts
@@ -130,10 +130,13 @@ export interface CanvasProps {
 	 */
 	height: string;
 	/**
-	 * Base DOM id used for the SVG canvas and generated SVG definitions.
+	 * DOM id applied to the rendered SVG canvas.
 	 *
 	 * @remarks
-	 * Use a unique id when rendering more than one canvas on the same page.
+	 * Internal SVG definitions such as masks and background patterns are isolated
+	 * per canvas instance, so multiple canvases can use the default id without
+	 * sharing those internal references. Provide a unique id when application code
+	 * needs to select or label a specific canvas element.
 	 *
 	 * @defaultValue `"react-sketch-canvas"`
 	 */

--- a/packages/react-sketch-canvas/src/Paths/geometry.ts
+++ b/packages/react-sketch-canvas/src/Paths/geometry.ts
@@ -1,4 +1,4 @@
-import type { Point } from "../types";
+import type { CanvasPath, Point } from "../types";
 
 type ControlPoints = {
 	current: Point;
@@ -11,6 +11,15 @@ type LineReturns = {
 	length: number;
 	angle: number;
 };
+
+type DoesEraserStrokeHitStrokeParams = {
+	eraser: CanvasPath;
+	stroke: CanvasPath;
+};
+
+type DoesEraserStrokeHitStrokeReturns = boolean;
+
+type Segment = readonly [Point, Point];
 
 /**
  * Calculate distance and angle between two points.
@@ -80,3 +89,123 @@ export const bezierCommand = (point: Point, i: number, a: Point[]): string => {
 
 	return `C ${cpsX},${cpsY} ${cpeX},${cpeY} ${point.x}, ${point.y}`;
 };
+
+const distanceBetweenPoints = (pointA: Point, pointB: Point): number =>
+	line(pointA, pointB).length;
+
+const distanceFromPointToSegment = (
+	point: Point,
+	[start, end]: Segment,
+): number => {
+	const lengthSquared = distanceBetweenPoints(start, end) ** 2;
+
+	if (lengthSquared === 0) {
+		return distanceBetweenPoints(point, start);
+	}
+
+	const projection =
+		((point.x - start.x) * (end.x - start.x) +
+			(point.y - start.y) * (end.y - start.y)) /
+		lengthSquared;
+	const boundedProjection = Math.max(0, Math.min(1, projection));
+	const closestPoint = {
+		x: start.x + boundedProjection * (end.x - start.x),
+		y: start.y + boundedProjection * (end.y - start.y),
+	};
+
+	return distanceBetweenPoints(point, closestPoint);
+};
+
+const orientation = (pointA: Point, pointB: Point, pointC: Point): number =>
+	(pointB.y - pointA.y) * (pointC.x - pointB.x) -
+	(pointB.x - pointA.x) * (pointC.y - pointB.y);
+
+const isPointOnSegment = (point: Point, [start, end]: Segment): boolean =>
+	point.x <= Math.max(start.x, end.x) &&
+	point.x >= Math.min(start.x, end.x) &&
+	point.y <= Math.max(start.y, end.y) &&
+	point.y >= Math.min(start.y, end.y);
+
+const doSegmentsIntersect = (
+	[firstStart, firstEnd]: Segment,
+	[secondStart, secondEnd]: Segment,
+): boolean => {
+	const firstOrientation = orientation(firstStart, firstEnd, secondStart);
+	const secondOrientation = orientation(firstStart, firstEnd, secondEnd);
+	const thirdOrientation = orientation(secondStart, secondEnd, firstStart);
+	const fourthOrientation = orientation(secondStart, secondEnd, firstEnd);
+
+	if (
+		((firstOrientation > 0 && secondOrientation < 0) ||
+			(firstOrientation < 0 && secondOrientation > 0)) &&
+		((thirdOrientation > 0 && fourthOrientation < 0) ||
+			(thirdOrientation < 0 && fourthOrientation > 0))
+	) {
+		return true;
+	}
+
+	return (
+		(firstOrientation === 0 &&
+			isPointOnSegment(secondStart, [firstStart, firstEnd])) ||
+		(secondOrientation === 0 &&
+			isPointOnSegment(secondEnd, [firstStart, firstEnd])) ||
+		(thirdOrientation === 0 &&
+			isPointOnSegment(firstStart, [secondStart, secondEnd])) ||
+		(fourthOrientation === 0 &&
+			isPointOnSegment(firstEnd, [secondStart, secondEnd]))
+	);
+};
+
+const distanceBetweenSegments = (
+	firstSegment: Segment,
+	secondSegment: Segment,
+): number => {
+	if (doSegmentsIntersect(firstSegment, secondSegment)) {
+		return 0;
+	}
+
+	const [firstStart, firstEnd] = firstSegment;
+	const [secondStart, secondEnd] = secondSegment;
+
+	return Math.min(
+		distanceFromPointToSegment(firstStart, secondSegment),
+		distanceFromPointToSegment(firstEnd, secondSegment),
+		distanceFromPointToSegment(secondStart, firstSegment),
+		distanceFromPointToSegment(secondEnd, firstSegment),
+	);
+};
+
+const strokeSegments = (stroke: CanvasPath): Segment[] =>
+	stroke.paths.length > 1
+		? stroke.paths
+				.slice(1)
+				.map((point, index) => [stroke.paths[index] as Point, point])
+		: stroke.paths.map((point) => [point, point]);
+
+/**
+ * Check whether a stroke-mode eraser gesture intersects a drawing stroke.
+ *
+ * @remarks
+ * The eraser is treated as a swept stroke. A drawing stroke is affected when
+ * any point or segment is within half the eraser width plus half the target
+ * stroke width, including single-point dot strokes.
+ */
+export function doesEraserStrokeHitStroke({
+	eraser,
+	stroke,
+}: DoesEraserStrokeHitStrokeParams): DoesEraserStrokeHitStrokeReturns {
+	if (eraser.paths.length === 0 || stroke.paths.length === 0) {
+		return false;
+	}
+
+	const threshold = eraser.strokeWidth / 2 + stroke.strokeWidth / 2;
+	const eraserSegments = strokeSegments(eraser);
+	const targetSegments = strokeSegments(stroke);
+
+	return eraserSegments.some((eraserSegment) =>
+		targetSegments.some(
+			(targetSegment) =>
+				distanceBetweenSegments(eraserSegment, targetSegment) <= threshold,
+		),
+	);
+}

--- a/packages/react-sketch-canvas/src/Paths/geometry.ts
+++ b/packages/react-sketch-canvas/src/Paths/geometry.ts
@@ -93,6 +93,13 @@ export const bezierCommand = (point: Point, i: number, a: Point[]): string => {
 const distanceBetweenPoints = (pointA: Point, pointB: Point): number =>
 	line(pointA, pointB).length;
 
+/**
+ * Measure the shortest distance from a point to a finite line segment.
+ *
+ * @remarks
+ * The projected point is clamped to the segment endpoints, so this works for
+ * both normal segments and degenerate single-point segments.
+ */
 const distanceFromPointToSegment = (
 	point: Point,
 	[start, end]: Segment,
@@ -116,16 +123,34 @@ const distanceFromPointToSegment = (
 	return distanceBetweenPoints(point, closestPoint);
 };
 
+/**
+ * Return the signed orientation of three points.
+ *
+ * @remarks
+ * Segment intersection uses the sign to determine whether two points sit on
+ * opposite sides of another segment. A zero value means the points are
+ * collinear.
+ */
 const orientation = (pointA: Point, pointB: Point, pointC: Point): number =>
 	(pointB.y - pointA.y) * (pointC.x - pointB.x) -
 	(pointB.x - pointA.x) * (pointC.y - pointB.y);
 
+/**
+ * Check whether a collinear point lies within a segment's bounding box.
+ */
 const isPointOnSegment = (point: Point, [start, end]: Segment): boolean =>
 	point.x <= Math.max(start.x, end.x) &&
 	point.x >= Math.min(start.x, end.x) &&
 	point.y <= Math.max(start.y, end.y) &&
 	point.y >= Math.min(start.y, end.y);
 
+/**
+ * Determine whether two finite segments touch or cross.
+ *
+ * @remarks
+ * This handles both the normal crossing case and collinear endpoint overlap,
+ * which matters for eraser strokes that travel directly along a drawing stroke.
+ */
 const doSegmentsIntersect = (
 	[firstStart, firstEnd]: Segment,
 	[secondStart, secondEnd]: Segment,
@@ -156,6 +181,13 @@ const doSegmentsIntersect = (
 	);
 };
 
+/**
+ * Measure the shortest distance between two finite segments.
+ *
+ * @remarks
+ * Intersecting segments have zero distance. Otherwise, the minimum must occur
+ * between one segment endpoint and the opposite segment.
+ */
 const distanceBetweenSegments = (
 	firstSegment: Segment,
 	secondSegment: Segment,
@@ -175,6 +207,13 @@ const distanceBetweenSegments = (
 	);
 };
 
+/**
+ * Convert a stroke's point list into finite segments for hit testing.
+ *
+ * @remarks
+ * Single-point strokes are represented as degenerate segments so dots can be
+ * erased with the same distance logic as multi-point strokes.
+ */
 const strokeSegments = (stroke: CanvasPath): Segment[] =>
 	stroke.paths.length > 1
 		? stroke.paths

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useCallback } from "react";
+import { doesEraserStrokeHitStroke } from "../../Paths/geometry";
 import type { CanvasPath, Point } from "../../types";
 import {
 	addLastStrokeToHistory,
@@ -25,6 +26,7 @@ type UseSketchCanvasControllerParams = Required<
 		| "strokeColor"
 		| "strokeWidth"
 		| "eraserWidth"
+		| "eraserMode"
 		| "withTimestamp"
 		| "onChange"
 		| "onStroke"
@@ -55,6 +57,7 @@ export function useSketchCanvasController({
 	strokeColor,
 	strokeWidth,
 	eraserWidth,
+	eraserMode,
 	withTimestamp,
 	onChange,
 	onStroke,
@@ -65,24 +68,32 @@ export function useSketchCanvasController({
 
 	const currentPaths = state.currentPaths;
 	const isDrawing = state.isDrawing;
-
-	// Keep the legacy stroke callback timing: the completed stroke is reported
-	// on the render after drawing transitions from active to inactive.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: preserve legacy stroke-lift timing tied only to drawing state changes.
-	const liftStrokeUp = React.useCallback((): void => {
-		const lastStroke = currentPaths.slice(-1)?.[0] ?? null;
-		if (lastStroke === null) return;
-
-		onStroke(lastStroke, !lastStroke.drawMode);
-	}, [isDrawing]);
+	const onChangeRef = React.useRef(onChange);
+	const onStrokeRef = React.useRef(onStroke);
 
 	React.useEffect(() => {
-		liftStrokeUp();
-	}, [liftStrokeUp]);
+		onChangeRef.current = onChange;
+	}, [onChange]);
 
 	React.useEffect(() => {
-		onChange(currentPaths);
-	}, [currentPaths, onChange]);
+		onStrokeRef.current = onStroke;
+	}, [onStroke]);
+
+	React.useEffect(() => {
+		if (isDrawing || state.lastCompletedStroke === null) return;
+
+		const completedStroke = state.lastCompletedStroke;
+		onStrokeRef.current(completedStroke.path, completedStroke.isEraser);
+		setState((current) =>
+			current.lastCompletedStroke === completedStroke
+				? { ...current, lastCompletedStroke: null }
+				: current,
+		);
+	}, [isDrawing, state.lastCompletedStroke]);
+
+	React.useEffect(() => {
+		onChangeRef.current(currentPaths);
+	}, [currentPaths]);
 
 	React.useEffect(() => {
 		if (state.isProcessingQueue || state.operationQueue.length === 0) return;
@@ -132,22 +143,36 @@ export function useSketchCanvasController({
 					withTimestamp,
 					now: Date.now(),
 				});
+				const isStrokeEraser = !isDraw && eraserMode === "stroke";
 
 				return {
 					...synced,
 					isDrawing: true,
 					historyPos: synced.historyPos + 1,
 					historySynced: false,
-					currentPaths: [...synced.currentPaths, stroke],
+					activeStroke: isStrokeEraser ? stroke : null,
+					currentPaths: isStrokeEraser
+						? synced.currentPaths
+						: [...synced.currentPaths, stroke],
 				};
 			});
 		},
-		[eraserWidth, strokeColor, strokeWidth, withTimestamp],
+		[eraserMode, eraserWidth, strokeColor, strokeWidth, withTimestamp],
 	);
 
 	const handlePointerMove = useCallback((point: Point): void => {
 		setState((current) => {
 			if (!current.isDrawing) return current;
+
+			if (current.activeStroke !== null) {
+				return {
+					...current,
+					activeStroke: appendPointToLastStroke(
+						[current.activeStroke],
+						point,
+					)[0] as CanvasPath,
+				};
+			}
 
 			return {
 				...current,
@@ -160,14 +185,48 @@ export function useSketchCanvasController({
 		setState((current) => {
 			if (!current.isDrawing) return current;
 
+			if (current.activeStroke !== null) {
+				const [eraserStroke] = finishStroke(
+					[current.activeStroke],
+					withTimestamp,
+					Date.now(),
+				);
+				const updatedPaths = current.currentPaths.filter(
+					(path) =>
+						!path.drawMode ||
+						!doesEraserStrokeHitStroke({ eraser: eraserStroke, stroke: path }),
+				);
+
+				return {
+					...current,
+					isDrawing: false,
+					activeStroke: null,
+					currentPaths: updatedPaths,
+					lastCompletedStroke: {
+						path: eraserStroke,
+						isEraser: true,
+					},
+				};
+			}
+
+			const currentPaths = finishStroke(
+				current.currentPaths,
+				withTimestamp,
+				Date.now(),
+			);
+			const lastStroke = currentPaths.slice(-1)?.[0] ?? null;
+
 			return {
 				...current,
 				isDrawing: false,
-				currentPaths: finishStroke(
-					current.currentPaths,
-					withTimestamp,
-					Date.now(),
-				),
+				currentPaths,
+				lastCompletedStroke:
+					lastStroke === null
+						? null
+						: {
+								path: lastStroke,
+								isEraser: !lastStroke.drawMode,
+							},
 			};
 		});
 	}, [withTimestamp]);

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts
@@ -196,12 +196,18 @@ export function useSketchCanvasController({
 						!path.drawMode ||
 						!doesEraserStrokeHitStroke({ eraser: eraserStroke, stroke: path }),
 				);
+				const didEraseStroke =
+					updatedPaths.length < current.currentPaths.length;
 
 				return {
 					...current,
 					isDrawing: false,
 					activeStroke: null,
-					currentPaths: updatedPaths,
+					currentPaths: didEraseStroke ? updatedPaths : current.currentPaths,
+					historyPos: didEraseStroke
+						? current.historyPos
+						: current.historyPos - 1,
+					historySynced: didEraseStroke ? current.historySynced : true,
 					lastCompletedStroke: {
 						path: eraserStroke,
 						isEraser: true,

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx
@@ -39,6 +39,7 @@ export const ReactSketchCanvas = React.forwardRef<
 		preserveBackgroundImageAspectRatio = "none",
 		strokeWidth = 4,
 		eraserWidth = 8,
+		eraserMode = "mask",
 		allowOnlyPointerType = "all",
 		style = {
 			border: "0.0625rem solid lightgray",
@@ -66,6 +67,7 @@ export const ReactSketchCanvas = React.forwardRef<
 		strokeColor,
 		strokeWidth,
 		eraserWidth,
+		eraserMode,
 		withTimestamp,
 		onChange,
 		onStroke,

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/state/history.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/state/history.ts
@@ -1,6 +1,11 @@
 import type { CanvasPath } from "../../types";
 import type { Operation } from "./operations";
 
+export type CompletedStroke = {
+	path: CanvasPath;
+	isEraser: boolean;
+};
+
 /**
  * Internal state model for `ReactSketchCanvas`.
  *
@@ -16,6 +21,8 @@ export type SketchState = {
 	historyPos: number;
 	historySynced: boolean;
 	currentPaths: CanvasPath[];
+	activeStroke: CanvasPath | null;
+	lastCompletedStroke: CompletedStroke | null;
 	operationQueue: Operation[];
 	isProcessingQueue: boolean;
 };
@@ -31,6 +38,8 @@ export function createInitialSketchState(): SketchState {
 		historyPos: 0,
 		historySynced: false,
 		currentPaths: [],
+		activeStroke: null,
+		lastCompletedStroke: null,
 		operationQueue: [],
 		isProcessingQueue: false,
 	};

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/types.ts
@@ -2,6 +2,18 @@ import type { CanvasProps, CanvasRef } from "../Canvas/types";
 import type { CanvasPath } from "../types";
 
 /**
+ * Eraser behavior used for pointer erasing.
+ *
+ * @remarks
+ * `"mask"` stores eraser gestures as mask paths, preserving the historical
+ * export and undo/redo behavior. `"stroke"` removes whole drawing strokes
+ * touched by the eraser gesture instead of storing the gesture path.
+ *
+ * @public
+ */
+export type EraserMode = "mask" | "stroke";
+
+/**
  * Props for the stateful {@link ReactSketchCanvas} component.
  *
  * @remarks
@@ -29,6 +41,17 @@ export interface ReactSketchCanvasProps
 	 * @defaultValue `8`
 	 */
 	eraserWidth?: number;
+	/**
+	 * Eraser behavior used when `eraseMode(true)` is active or a pen eraser
+	 * button is detected.
+	 *
+	 * @remarks
+	 * Use `"mask"` to preserve eraser gestures as SVG mask paths. Use `"stroke"`
+	 * when erasing should delete whole drawing strokes touched by the eraser.
+	 *
+	 * @defaultValue `"mask"`
+	 */
+	eraserMode?: EraserMode;
 	/**
 	 * Called whenever the rendered path list changes.
 	 *

--- a/packages/react-sketch-canvas/src/index.tsx
+++ b/packages/react-sketch-canvas/src/index.tsx
@@ -13,6 +13,7 @@ export * from "./ReactSketchCanvas";
  * Stateful sketch canvas props and ref types for the primary public component.
  */
 export type {
+	EraserMode,
 	ReactSketchCanvasProps,
 	ReactSketchCanvasRef,
 } from "./ReactSketchCanvas/types";

--- a/packages/react-sketch-canvas/tests/actions/erase.spec.tsx
+++ b/packages/react-sketch-canvas/tests/actions/erase.spec.tsx
@@ -56,32 +56,6 @@ test.describe("eraser", () => {
 		);
 	});
 
-	test("should use explicit mask paint values with Dark Reader guard markup", async ({
-		mount,
-	}) => {
-		const canvasId = "rsc";
-		const eraserButtonId = "eraser-button";
-
-		const component = await mount(
-			<WithEraserButton id={canvasId} eraserButtonId={eraserButtonId} />,
-		);
-
-		const canvas = component.locator(`#${canvasId}`);
-
-		await drawLine(canvas, { length: 50, originX: 0, originY: 10 });
-		await component.locator(`#${eraserButtonId}`).click();
-		await drawLine(canvas, { length: 10, originX: 0, originY: 10 });
-
-		const mask = canvas.locator('mask[id$="__eraser-mask-0"]');
-		const maskBackground = canvas.locator('[id$="__mask-background"]');
-		const eraserStroke = canvas.locator('[id$="__eraser-0"]');
-
-		await expect(mask).toHaveClass(/darkreader-ignore/);
-		await expect(mask).toHaveAttribute("style", /color-scheme:\s*light/i);
-		await expect(maskBackground).toHaveAttribute("fill", "#fff");
-		await expect(eraserStroke).toHaveAttribute("stroke", "#000");
-	});
-
 	test("should trigger erase mode and add a mask for erasing previous strokes", async ({
 		mount,
 	}) => {

--- a/packages/react-sketch-canvas/tests/actions/erase.spec.tsx
+++ b/packages/react-sketch-canvas/tests/actions/erase.spec.tsx
@@ -1,11 +1,87 @@
 import { expect, test } from "@playwright/experimental-ct-react";
-import { ReactSketchCanvas } from "../../src";
+import { type CanvasPath, ReactSketchCanvas } from "../../src";
 import { drawLine, getCanvasIds } from "../commands";
 import { WithEraserButton } from "../stories/WithEraserButton.story";
+import { WithExportPathsButton } from "../stories/WithExportPathsButton.story";
+import { WithUndoRedoButtons } from "../stories/WithUndoRedoButtons";
 
 test.use({ viewport: { width: 500, height: 500 } });
 
 test.describe("eraser", () => {
+	test("should keep eraser masks isolated across canvases with the default public id", async ({
+		mount,
+	}) => {
+		const firstEraserButtonId = "first-eraser-button";
+		const secondEraserButtonId = "second-eraser-button";
+
+		const component = await mount(
+			<div>
+				<WithEraserButton eraserButtonId={firstEraserButtonId} />
+				<WithEraserButton eraserButtonId={secondEraserButtonId} />
+			</div>,
+		);
+
+		const firstCanvas = component
+			.locator('svg[id="react-sketch-canvas"]')
+			.nth(0);
+		const secondCanvas = component
+			.locator('svg[id="react-sketch-canvas"]')
+			.nth(1);
+
+		await drawLine(firstCanvas, { length: 50, originX: 0, originY: 10 });
+		await component.locator(`#${firstEraserButtonId}`).click();
+		await drawLine(firstCanvas, { length: 10, originX: 0, originY: 10 });
+
+		await drawLine(secondCanvas, { length: 50, originX: 10, originY: 20 });
+		await component.locator(`#${secondEraserButtonId}`).click();
+		await drawLine(secondCanvas, { length: 10, originX: 10, originY: 20 });
+
+		const firstStrokeGroup = firstCanvas.locator('[id$="__stroke-group-0"]');
+		const secondStrokeGroup = secondCanvas.locator('[id$="__stroke-group-0"]');
+		const firstMask = firstCanvas.locator('mask[id$="__eraser-mask-0"]');
+		const secondMask = secondCanvas.locator('mask[id$="__eraser-mask-0"]');
+		const firstMaskId = await firstMask.getAttribute("id");
+		const secondMaskId = await secondMask.getAttribute("id");
+
+		expect(firstMaskId).toBeTruthy();
+		expect(secondMaskId).toBeTruthy();
+		expect(firstMaskId).not.toBe(secondMaskId);
+		await expect(firstStrokeGroup).toHaveAttribute(
+			"mask",
+			`url(#${firstMaskId})`,
+		);
+		await expect(secondStrokeGroup).toHaveAttribute(
+			"mask",
+			`url(#${secondMaskId})`,
+		);
+	});
+
+	test("should use explicit mask paint values with Dark Reader guard markup", async ({
+		mount,
+	}) => {
+		const canvasId = "rsc";
+		const eraserButtonId = "eraser-button";
+
+		const component = await mount(
+			<WithEraserButton id={canvasId} eraserButtonId={eraserButtonId} />,
+		);
+
+		const canvas = component.locator(`#${canvasId}`);
+
+		await drawLine(canvas, { length: 50, originX: 0, originY: 10 });
+		await component.locator(`#${eraserButtonId}`).click();
+		await drawLine(canvas, { length: 10, originX: 0, originY: 10 });
+
+		const mask = canvas.locator('mask[id$="__eraser-mask-0"]');
+		const maskBackground = canvas.locator('[id$="__mask-background"]');
+		const eraserStroke = canvas.locator('[id$="__eraser-0"]');
+
+		await expect(mask).toHaveClass(/darkreader-ignore/);
+		await expect(mask).toHaveAttribute("style", /color-scheme:\s*light/i);
+		await expect(maskBackground).toHaveAttribute("fill", "#fff");
+		await expect(eraserStroke).toHaveAttribute("stroke", "#000");
+	});
+
 	test("should trigger erase mode and add a mask for erasing previous strokes", async ({
 		mount,
 	}) => {
@@ -23,10 +99,8 @@ test.describe("eraser", () => {
 
 		const {
 			eraserStrokeGroupId,
-			firstEraserMaskId,
 			firstEraserMask,
 			firstStrokeGroupId,
-			secondEraserMaskId,
 			secondStrokeGroupId,
 			secondEraserMask,
 		} = getCanvasIds(canvasId);
@@ -56,6 +130,9 @@ test.describe("eraser", () => {
 		).toHaveCount(1);
 		// Check that the eraser mask is added
 		await expect(canvas.locator(firstEraserMask).locator("use")).toHaveCount(2);
+		const firstEraserMaskId = await canvas
+			.locator(firstEraserMask)
+			.getAttribute("id");
 
 		// Check that the first stroke group has the eraser mask
 		await expect(canvas.locator(firstStrokeGroupId)).toHaveAttribute(
@@ -95,6 +172,9 @@ test.describe("eraser", () => {
 		await expect(canvas.locator(secondEraserMask).locator("use")).toHaveCount(
 			2,
 		); // background + eraser mask
+		const secondEraserMaskId = await canvas
+			.locator(secondEraserMask)
+			.getAttribute("id");
 
 		// Check that the second stroke group has the eraser mask
 		await expect(canvas.locator(secondStrokeGroupId)).toHaveAttribute(
@@ -160,10 +240,14 @@ test.describe("eraser", () => {
 		await penButton.click();
 		await drawLine(canvas, { length: 50, originX: 10, originY: 20 });
 
+		const firstEraserMaskId = await canvas
+			.locator('mask[id$="__eraser-mask-0"]')
+			.getAttribute("id");
+
 		// First stroke group should have the eraser mask
 		await expect(canvas.locator(firstStrokeGroupId)).toHaveAttribute(
 			"mask",
-			`url(#${canvasId}__eraser-mask-0)`,
+			`url(#${firstEraserMaskId})`,
 		);
 
 		// Second stroke group (after last eraser) should NOT have a mask
@@ -179,12 +263,8 @@ test.describe("eraser", () => {
 
 		const canvas = await mount(<ReactSketchCanvas id={canvasId} />);
 
-		const {
-			eraserStrokeGroupId,
-			firstEraserMaskId,
-			firstEraserMask,
-			firstStrokeGroupId,
-		} = getCanvasIds(canvasId);
+		const { eraserStrokeGroupId, firstEraserMask, firstStrokeGroupId } =
+			getCanvasIds(canvasId);
 
 		// First stroke
 		await drawLine(canvas, {
@@ -209,6 +289,9 @@ test.describe("eraser", () => {
 		).toHaveCount(1);
 		// Check that the eraser mask is added
 		await expect(canvas.locator(firstEraserMask).locator("use")).toHaveCount(2);
+		const firstEraserMaskId = await canvas
+			.locator(firstEraserMask)
+			.getAttribute("id");
 
 		// Check that the first stroke group has the eraser mask
 		await expect(canvas.locator(firstStrokeGroupId)).toHaveAttribute(
@@ -239,10 +322,158 @@ test.describe("eraser", () => {
 		await drawLine(canvas, { length: 10, originX: 0, originY: 10 });
 
 		const eraserStrokeGroup = canvas.locator(
-			`defs > #${canvasId}__eraser-stroke-group`,
+			'defs > [id$="__eraser-stroke-group"]',
 		);
 
 		await expect(eraserStrokeGroup.locator("path")).toHaveCount(1);
 		await expect(eraserStrokeGroup).not.toHaveAttribute("display", "none");
+	});
+
+	test.describe("stroke eraser mode", () => {
+		test("should delete whole affected strokes without rendering eraser masks", async ({
+			mount,
+		}) => {
+			const canvasId = "rsc";
+			const eraserButtonId = "eraser-button";
+			const component = await mount(
+				<WithEraserButton
+					id={canvasId}
+					eraserButtonId={eraserButtonId}
+					eraserMode="stroke"
+				/>,
+			);
+
+			const canvas = component.locator(`#${canvasId}`);
+			const { firstStrokeGroupId, eraserStrokeGroupId } =
+				getCanvasIds(canvasId);
+
+			await drawLine(canvas, { length: 50, originX: 0, originY: 10 });
+			await drawLine(canvas, { length: 50, originX: 0, originY: 80 });
+			await component.locator(`#${eraserButtonId}`).click();
+			await drawLine(canvas, { length: 10, originX: 0, originY: 10 });
+
+			await expect(
+				canvas.locator(firstStrokeGroupId).locator("path"),
+			).toHaveCount(1);
+			await expect(
+				canvas.locator(firstStrokeGroupId).locator("path"),
+			).toHaveAttribute("stroke", "red");
+			await expect(
+				canvas.locator(eraserStrokeGroupId).locator("path"),
+			).toHaveCount(0);
+			await expect(canvas.locator('mask[id$="__eraser-mask-0"]')).toHaveCount(
+				0,
+			);
+		});
+
+		test("should undo and redo a stroke eraser deletion", async ({ mount }) => {
+			const canvasId = "rsc";
+			const undoButtonId = "undo-button";
+			const redoButtonId = "redo-button";
+
+			const component = await mount(
+				<WithUndoRedoButtons
+					id={canvasId}
+					eraserMode="stroke"
+					undoButtonId={undoButtonId}
+					redoButtonId={redoButtonId}
+					paths={[]}
+				/>,
+			);
+
+			const canvas = component.locator(`#${canvasId}`);
+			const { firstStrokeGroupId } = getCanvasIds(canvasId);
+
+			await drawLine(canvas, { length: 50, originX: 0, originY: 10 });
+			await drawLine(canvas, {
+				length: 10,
+				originX: 0,
+				originY: 10,
+				pointerType: "pen",
+				eventButtons: 32,
+			});
+
+			await expect(
+				canvas.locator(firstStrokeGroupId).locator("path"),
+			).toHaveCount(0);
+
+			await component.locator(`#${undoButtonId}`).click();
+			await expect(
+				canvas.locator(firstStrokeGroupId).locator("path"),
+			).toHaveCount(1);
+
+			await component.locator(`#${redoButtonId}`).click();
+			await expect(
+				canvas.locator(firstStrokeGroupId).locator("path"),
+			).toHaveCount(0);
+		});
+
+		test("should export only remaining draw strokes", async ({ mount }) => {
+			const canvasId = "rsc";
+			const exportPathsButtonId = "export-paths-button";
+			const outputId = "paths-output";
+
+			const component = await mount(
+				<WithExportPathsButton
+					id={canvasId}
+					eraserMode="stroke"
+					exportPathsButtonId={exportPathsButtonId}
+					outputId={outputId}
+				/>,
+			);
+
+			const canvas = component.locator(`#${canvasId}`);
+			await drawLine(canvas, { length: 50, originX: 0, originY: 10 });
+			await drawLine(canvas, { length: 50, originX: 0, originY: 80 });
+			await drawLine(canvas, {
+				length: 10,
+				originX: 0,
+				originY: 10,
+				pointerType: "pen",
+				eventButtons: 32,
+			});
+
+			await component.locator(`#${exportPathsButtonId}`).click();
+
+			const exported = JSON.parse(
+				(await component.locator(`#${outputId}`).textContent()) ?? "[]",
+			) as CanvasPath[];
+
+			expect(exported).toHaveLength(1);
+			expect(exported[0]?.drawMode).toBe(true);
+			expect(exported[0]?.paths[0]?.y).toBeGreaterThan(50);
+		});
+
+		test("should use stroke eraser mode for pen eraser input", async ({
+			mount,
+		}) => {
+			const canvasId = "rsc";
+			const canvas = await mount(
+				<ReactSketchCanvas id={canvasId} eraserMode="stroke" />,
+			);
+			const { firstStrokeGroupId, eraserStrokeGroupId } =
+				getCanvasIds(canvasId);
+
+			await drawLine(canvas, {
+				length: 50,
+				originX: 0,
+				originY: 10,
+				pointerType: "pen",
+			});
+			await drawLine(canvas, {
+				length: 10,
+				originX: 0,
+				originY: 10,
+				pointerType: "pen",
+				eventButtons: 32,
+			});
+
+			await expect(
+				canvas.locator(firstStrokeGroupId).locator("path"),
+			).toHaveCount(0);
+			await expect(
+				canvas.locator(eraserStrokeGroupId).locator("path"),
+			).toHaveCount(0);
+		});
 	});
 });

--- a/packages/react-sketch-canvas/tests/actions/export.spec.tsx
+++ b/packages/react-sketch-canvas/tests/actions/export.spec.tsx
@@ -79,6 +79,12 @@ function dataURIPattern(imageType: ExportImageType) {
 }
 
 function exportedIdFragment(idOrSelector: string) {
+	const internalSuffix = idOrSelector.match(/\[id\$="([^"]+)"\]/)?.[1];
+
+	if (internalSuffix) {
+		return internalSuffix;
+	}
+
 	return idOrSelector.replace(/^#?[^_]+__/, "");
 }
 
@@ -560,7 +566,7 @@ test.describe("export SVG", () => {
 			const { firstStrokePathId } = getCanvasIds(canvasId);
 
 			await exportSVGButton.click();
-			expect(svg).not.toContain(firstStrokePathId.slice(1));
+			expect(svg).not.toContain(exportedIdFragment(firstStrokePathId));
 
 			await drawSquaresAndWaitForStroke(canvas);
 
@@ -583,8 +589,8 @@ test.describe("export SVG", () => {
 			const { firstStrokePathId, firstEraserStrokeId } = getCanvasIds(canvasId);
 
 			await exportSVGButton.click();
-			expect(svg).not.toContain(firstStrokePathId.slice(1));
-			expect(svg).not.toContain(firstEraserStrokeId.slice(1));
+			expect(svg).not.toContain(exportedIdFragment(firstStrokePathId));
+			expect(svg).not.toContain(exportedIdFragment(firstEraserStrokeId));
 
 			await drawSquaresAndWaitForStroke(canvas);
 
@@ -619,7 +625,7 @@ test.describe("export SVG", () => {
 			await exportSVGButton.click();
 			expect(svg).toContain(backgroundUrl);
 			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
-			expect(svg).not.toContain(firstStrokePathId.slice(1));
+			expect(svg).not.toContain(exportedIdFragment(firstStrokePathId));
 
 			await drawSquaresAndWaitForStroke(canvas);
 
@@ -649,8 +655,8 @@ test.describe("export SVG", () => {
 			await exportSVGButton.click();
 			expect(svg).toContain(backgroundUrl);
 			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
-			expect(svg).not.toContain(firstStrokePathId.slice(1));
-			expect(svg).not.toContain(firstEraserStrokeId.slice(1));
+			expect(svg).not.toContain(exportedIdFragment(firstStrokePathId));
+			expect(svg).not.toContain(exportedIdFragment(firstEraserStrokeId));
 
 			await drawSquaresAndWaitForStroke(canvas);
 
@@ -658,7 +664,7 @@ test.describe("export SVG", () => {
 			expect(svg).toContain(backgroundUrl);
 			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
 			expect(svg).toContain(exportedIdFragment(firstStrokePathId));
-			expect(svg).not.toContain(firstEraserStrokeId.slice(1));
+			expect(svg).not.toContain(exportedIdFragment(firstEraserStrokeId));
 
 			await eraserButton.click();
 			await drawSquaresAndWaitForEraser(canvas);
@@ -688,7 +694,7 @@ test.describe("export SVG", () => {
 
 			await exportSVGButton.click();
 			expect(svg).not.toContain(backgroundUrl);
-			expect(svg).not.toContain(firstStrokePathId.slice(1));
+			expect(svg).not.toContain(exportedIdFragment(firstStrokePathId));
 
 			await drawSquaresAndWaitForStroke(canvas);
 
@@ -718,8 +724,8 @@ test.describe("export SVG", () => {
 			await exportSVGButton.click();
 			expect(svg).not.toContain(backgroundUrl);
 			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
-			expect(svg).not.toContain(firstStrokePathId.slice(1));
-			expect(svg).not.toContain(firstEraserStrokeId.slice(1));
+			expect(svg).not.toContain(exportedIdFragment(firstStrokePathId));
+			expect(svg).not.toContain(exportedIdFragment(firstEraserStrokeId));
 
 			await drawSquaresAndWaitForStroke(canvas);
 
@@ -727,7 +733,7 @@ test.describe("export SVG", () => {
 			expect(svg).not.toContain(backgroundUrl);
 			expect(svg).toContain(exportedIdFragment(canvasBackgroundId));
 			expect(svg).toContain(exportedIdFragment(firstStrokePathId));
-			expect(svg).not.toContain(firstEraserStrokeId.slice(1));
+			expect(svg).not.toContain(exportedIdFragment(firstEraserStrokeId));
 
 			await eraserButton.click();
 			await drawSquaresAndWaitForEraser(canvas);

--- a/packages/react-sketch-canvas/tests/commands.ts
+++ b/packages/react-sketch-canvas/tests/commands.ts
@@ -2,18 +2,19 @@ import type { Locator } from "playwright/test";
 import type { DrawLineArgs, DrawPointArgs, DrawSquareArgs } from "./types";
 
 export function getCanvasIds(id: string) {
-	const canvasBackgroundId = `#${id}__canvas-background`;
-	const backgroundImagePatternId = `pattern#${id}__background image`;
-	const firstStrokeGroupId = `#${id}__stroke-group-0`;
-	const secondStrokeGroupId = `#${id}__stroke-group-1`;
-	const eraserStrokeGroupId = `#${id}__eraser-stroke-group`;
+	void id;
+	const canvasBackgroundId = '[id$="__canvas-background"]';
+	const backgroundImagePatternId = 'pattern[id$="__background"] image';
+	const firstStrokeGroupId = '[id$="__stroke-group-0"]';
+	const secondStrokeGroupId = '[id$="__stroke-group-1"]';
+	const eraserStrokeGroupId = '[id$="__eraser-stroke-group"]';
 
-	const firstStrokePathId = `#${id}__stroke-group-0__paths__0`;
-	const firstEraserStrokeId = `#${id}__eraser-0`;
-	const firstEraserMaskId = `${id}__eraser-mask-0`;
-	const firstEraserMask = `mask#${firstEraserMaskId}`;
-	const secondEraserMaskId = `${id}__eraser-mask-1`;
-	const secondEraserMask = `mask#${secondEraserMaskId}`;
+	const firstStrokePathId = '[id$="__stroke-group-0__paths__0"]';
+	const firstEraserStrokeId = '[id$="__eraser-0"]';
+	const firstEraserMaskId = "__eraser-mask-0";
+	const firstEraserMask = 'mask[id$="__eraser-mask-0"]';
+	const secondEraserMaskId = "__eraser-mask-1";
+	const secondEraserMask = 'mask[id$="__eraser-mask-1"]';
 
 	return {
 		canvasBackgroundId,

--- a/packages/react-sketch-canvas/tests/props/basic.spec.tsx
+++ b/packages/react-sketch-canvas/tests/props/basic.spec.tsx
@@ -32,16 +32,49 @@ test("should update backgroundImage from props", async ({ mount }) => {
 
 	const { canvasBackgroundId, backgroundImagePatternId } =
 		getCanvasIds(canvasId);
+	const backgroundPattern = component.locator('pattern[id$="__background"]');
+	const backgroundPatternId = await backgroundPattern.getAttribute("id");
 
 	await expect(component.locator(canvasBackgroundId)).toHaveAttribute(
 		"fill",
-		`url(#${canvasId}__background)`,
+		`url(#${backgroundPatternId})`,
 	);
 
 	await expect(component.locator(backgroundImagePatternId)).toHaveAttribute(
 		"xlink:href",
 		backgroundImageUrl,
 	);
+});
+
+test("should isolate background pattern ids across canvases with the default public id", async ({
+	mount,
+}) => {
+	const backgroundImageUrl = "https://placehold.co/600x400.png";
+	const component = await mount(
+		<div>
+			<ReactSketchCanvas backgroundImage={backgroundImageUrl} />
+			<ReactSketchCanvas backgroundImage={backgroundImageUrl} />
+		</div>,
+	);
+
+	const firstCanvas = component.locator('svg[id="react-sketch-canvas"]').nth(0);
+	const secondCanvas = component
+		.locator('svg[id="react-sketch-canvas"]')
+		.nth(1);
+	const firstPattern = firstCanvas.locator('pattern[id$="__background"]');
+	const secondPattern = secondCanvas.locator('pattern[id$="__background"]');
+	const firstPatternId = await firstPattern.getAttribute("id");
+	const secondPatternId = await secondPattern.getAttribute("id");
+
+	expect(firstPatternId).toBeTruthy();
+	expect(secondPatternId).toBeTruthy();
+	expect(firstPatternId).not.toBe(secondPatternId);
+	await expect(
+		firstCanvas.locator('[id$="__canvas-background"]'),
+	).toHaveAttribute("fill", `url(#${firstPatternId})`);
+	await expect(
+		secondCanvas.locator('[id$="__canvas-background"]'),
+	).toHaveAttribute("fill", `url(#${secondPatternId})`);
 });
 
 test("should update preserveAspectRatio of the background image from props", async ({

--- a/packages/react-sketch-canvas/tests/stories/WithExportPathsButton.story.tsx
+++ b/packages/react-sketch-canvas/tests/stories/WithExportPathsButton.story.tsx
@@ -1,0 +1,38 @@
+import { type ComponentProps, useRef, useState } from "react";
+import {
+	type CanvasPath,
+	ReactSketchCanvas,
+	type ReactSketchCanvasRef,
+} from "../../src";
+
+type WithExportPathsButtonProps = ComponentProps<typeof ReactSketchCanvas> & {
+	exportPathsButtonId: string;
+	outputId: string;
+};
+
+export function WithExportPathsButton({
+	exportPathsButtonId,
+	outputId,
+	...canvasProps
+}: WithExportPathsButtonProps) {
+	const canvasRef = useRef<ReactSketchCanvasRef>(null);
+	const [paths, setPaths] = useState<CanvasPath[]>([]);
+
+	const handleExportPaths = async () => {
+		setPaths((await canvasRef.current?.exportPaths()) ?? []);
+	};
+
+	return (
+		<div>
+			<ReactSketchCanvas ref={canvasRef} {...canvasProps} />
+			<button
+				id={exportPathsButtonId}
+				type="button"
+				onClick={handleExportPaths}
+			>
+				Export paths
+			</button>
+			<output id={outputId}>{JSON.stringify(paths)}</output>
+		</div>
+	);
+}

--- a/packages/react-sketch-canvas/tests/unit/canvas/svgExport.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/canvas/svgExport.spec.ts
@@ -53,6 +53,24 @@ describe("canvas SVG export helpers", () => {
 		expect(exported.outerHTML).toContain('fill="pink"');
 	});
 
+	it("removes internally isolated background ids when exporting without background image", () => {
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+		svg.innerHTML = `
+			<defs><pattern id="canvas__r0__background"></pattern></defs>
+			<rect id="canvas__r0__canvas-background" fill="url(#canvas__r0__background)"></rect>
+		`;
+
+		const exported = prepareSvgForExport(svg, {
+			id: "canvas",
+			canvasColor: "pink",
+			exportWithBackgroundImage: false,
+		});
+
+		expect(exported.outerHTML).not.toContain('id="canvas__r0__background"');
+		expect(exported.outerHTML).not.toContain("url(#canvas__r0__background)");
+		expect(exported.outerHTML).toContain('fill="pink"');
+	});
+
 	it("rewrites internal ids and references so exported SVG markup does not collide with the live canvas", () => {
 		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
 		svg.innerHTML = `

--- a/packages/react-sketch-canvas/tests/unit/paths/geometry.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/paths/geometry.spec.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { bezierCommand, line } from "../../../src/Paths/geometry";
+import {
+	bezierCommand,
+	doesEraserStrokeHitStroke,
+	line,
+} from "../../../src/Paths/geometry";
+import type { CanvasPath } from "../../../src/types";
+
+function path(paths: CanvasPath["paths"], strokeWidth = 4): CanvasPath {
+	return {
+		paths,
+		strokeWidth,
+		strokeColor: "red",
+		drawMode: true,
+	};
+}
 
 describe("Paths geometry", () => {
 	it("measures the length and angle between two points", () => {
@@ -19,5 +33,72 @@ describe("Paths geometry", () => {
 		expect(command.startsWith("C ")).toBe(true);
 		expect(command.endsWith(" 10, 0")).toBe(true);
 		expect(command).toMatch(/^C [^ ]+ [^ ]+ 10, 0$/);
+	});
+
+	it("detects crossing eraser and drawing segments", () => {
+		const eraser = path(
+			[
+				{ x: 5, y: -10 },
+				{ x: 5, y: 10 },
+			],
+			8,
+		);
+		const stroke = path([
+			{ x: 0, y: 0 },
+			{ x: 10, y: 0 },
+		]);
+
+		expect(doesEraserStrokeHitStroke({ eraser, stroke })).toBe(true);
+	});
+
+	it("does not hit a drawing segment outside the eraser radius", () => {
+		const eraser = path(
+			[
+				{ x: 0, y: 0 },
+				{ x: 10, y: 0 },
+			],
+			8,
+		);
+		const stroke = path(
+			[
+				{ x: 0, y: 9 },
+				{ x: 10, y: 9 },
+			],
+			4,
+		);
+
+		expect(doesEraserStrokeHitStroke({ eraser, stroke })).toBe(false);
+	});
+
+	it("detects single-point drawing strokes inside the swept eraser stroke", () => {
+		const eraser = path(
+			[
+				{ x: 0, y: 0 },
+				{ x: 10, y: 0 },
+			],
+			8,
+		);
+		const stroke = path([{ x: 5, y: 5 }], 4);
+
+		expect(doesEraserStrokeHitStroke({ eraser, stroke })).toBe(true);
+	});
+
+	it("includes half of the target stroke width in the hit threshold", () => {
+		const eraser = path(
+			[
+				{ x: 0, y: 0 },
+				{ x: 10, y: 0 },
+			],
+			8,
+		);
+		const stroke = path(
+			[
+				{ x: 0, y: 6 },
+				{ x: 10, y: 6 },
+			],
+			4,
+		);
+
+		expect(doesEraserStrokeHitStroke({ eraser, stroke })).toBe(true);
 	});
 });

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasController.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasController.spec.tsx
@@ -10,15 +10,18 @@ function Harness({
 	onReady,
 	onChange = vi.fn(),
 	onStroke = vi.fn(),
+	eraserMode = "mask",
 }: {
 	onReady: (controller: ControllerSnapshot) => void;
 	onChange?: (paths: CanvasPath[]) => void;
 	onStroke?: (path: CanvasPath, isEraser: boolean) => void;
+	eraserMode?: "mask" | "stroke";
 }) {
 	const controller = useSketchCanvasController({
 		strokeColor: "red",
 		strokeWidth: 4,
 		eraserWidth: 8,
+		eraserMode,
 		withTimestamp: false,
 		onChange,
 		onStroke,
@@ -79,5 +82,165 @@ describe("useSketchCanvasController", () => {
 			strokeColor: "#000000",
 			strokeWidth: 8,
 		});
+	});
+
+	it("reports each completed stroke once", async () => {
+		let controller: ControllerSnapshot | undefined;
+		const onStroke = vi.fn();
+
+		render(
+			<Harness
+				onStroke={onStroke}
+				onReady={(next) => {
+					controller = next;
+				}}
+			/>,
+		);
+
+		act(() => {
+			controller?.handlePointerDown({ x: 0, y: 0 });
+		});
+		act(() => {
+			controller?.handlePointerMove({ x: 10, y: 0 });
+		});
+		act(() => {
+			controller?.handlePointerUp();
+		});
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(onStroke).toHaveBeenCalledTimes(1);
+
+		act(() => {
+			controller?.handlePointerDown({ x: 0, y: 20 });
+		});
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(onStroke).toHaveBeenCalledTimes(1);
+
+		act(() => {
+			controller?.handlePointerMove({ x: 10, y: 20 });
+		});
+		act(() => {
+			controller?.handlePointerUp();
+		});
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(onStroke).toHaveBeenCalledTimes(2);
+	});
+
+	it("deletes affected draw strokes in stroke eraser mode without persisting the eraser path", async () => {
+		let controller: ControllerSnapshot | undefined;
+		const onChange = vi.fn();
+		const onStroke = vi.fn();
+
+		render(
+			<Harness
+				eraserMode="stroke"
+				onChange={onChange}
+				onStroke={onStroke}
+				onReady={(next) => {
+					controller = next;
+				}}
+			/>,
+		);
+
+		act(() => {
+			controller?.handlePointerDown({ x: 0, y: 0 });
+			controller?.handlePointerMove({ x: 20, y: 0 });
+			controller?.handlePointerUp();
+		});
+		act(() => {
+			controller?.handlePointerDown({ x: 0, y: 30 });
+			controller?.handlePointerMove({ x: 20, y: 30 });
+			controller?.handlePointerUp();
+		});
+		act(() => {
+			controller?.setEraseMode(true);
+		});
+		act(() => {
+			controller?.handlePointerDown({ x: 10, y: -5 });
+			controller?.handlePointerMove({ x: 10, y: 5 });
+		});
+		act(() => {
+			controller?.handlePointerUp();
+		});
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(controller?.currentPaths).toHaveLength(1);
+		expect(controller?.currentPaths[0]?.paths).toEqual([
+			{ x: 0, y: 30 },
+			{ x: 20, y: 30 },
+		]);
+		expect(controller?.currentPaths.every((path) => path.drawMode)).toBe(true);
+		expect(onChange).toHaveBeenLastCalledWith([
+			{
+				drawMode: true,
+				strokeColor: "red",
+				strokeWidth: 4,
+				paths: [
+					{ x: 0, y: 30 },
+					{ x: 20, y: 30 },
+				],
+			},
+		]);
+		expect(onStroke).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				drawMode: false,
+				paths: [
+					{ x: 10, y: -5 },
+					{ x: 10, y: 5 },
+				],
+			}),
+			true,
+		);
+	});
+
+	it("undoes and redoes stroke eraser deletions as one operation", async () => {
+		let controller: ControllerSnapshot | undefined;
+
+		render(
+			<Harness
+				eraserMode="stroke"
+				onReady={(next) => {
+					controller = next;
+				}}
+			/>,
+		);
+
+		act(() => {
+			controller?.handlePointerDown({ x: 0, y: 0 });
+			controller?.handlePointerMove({ x: 20, y: 0 });
+			controller?.handlePointerUp();
+		});
+		act(() => {
+			controller?.setEraseMode(true);
+		});
+		act(() => {
+			controller?.handlePointerDown({ x: 10, y: -5 });
+			controller?.handlePointerMove({ x: 10, y: 5 });
+			controller?.handlePointerUp();
+		});
+
+		expect(controller?.currentPaths).toHaveLength(0);
+
+		await act(async () => {
+			controller?.enqueueOperation({ type: "undo" });
+			await Promise.resolve();
+		});
+		expect(controller?.currentPaths).toHaveLength(1);
+
+		await act(async () => {
+			controller?.enqueueOperation({ type: "redo" });
+			await Promise.resolve();
+		});
+		expect(controller?.currentPaths).toHaveLength(0);
 	});
 });

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasController.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas/useSketchCanvasController.spec.tsx
@@ -243,4 +243,39 @@ describe("useSketchCanvasController", () => {
 		});
 		expect(controller?.currentPaths).toHaveLength(0);
 	});
+
+	it("does not add an undo step when a stroke eraser misses every draw stroke", async () => {
+		let controller: ControllerSnapshot | undefined;
+
+		render(
+			<Harness
+				eraserMode="stroke"
+				onReady={(next) => {
+					controller = next;
+				}}
+			/>,
+		);
+
+		act(() => {
+			controller?.handlePointerDown({ x: 0, y: 0 });
+			controller?.handlePointerMove({ x: 20, y: 0 });
+			controller?.handlePointerUp();
+		});
+		act(() => {
+			controller?.setEraseMode(true);
+		});
+		act(() => {
+			controller?.handlePointerDown({ x: 100, y: 100 });
+			controller?.handlePointerMove({ x: 120, y: 100 });
+			controller?.handlePointerUp();
+		});
+
+		expect(controller?.currentPaths).toHaveLength(1);
+
+		await act(async () => {
+			controller?.enqueueOperation({ type: "undo" });
+			await Promise.resolve();
+		});
+		expect(controller?.currentPaths).toHaveLength(0);
+	});
 });


### PR DESCRIPTION
## Summary
- Isolate internal SVG ids for masks and background patterns so multiple canvases with the same public id do not cross-reference each other.
- Namespace exported SVG ids and references so exported markup can coexist with the live canvas.
- Add opt-in `eraserMode="stroke"` while preserving the existing `eraserMode="mask"` behavior.
- Update API docs, the switching-modes example, shared example form control styles, and geometry helper TSDoc.

## Issue Coverage
- Fixes #142
- Fixes #177
- Fixes #200

## Scope Note
Dark Reader-specific changes were removed from this PR, so #120 is not marked as resolved here.

## Validation
- `pnpm --filter react-sketch-canvas test:ct -- tests/actions/erase.spec.tsx`
- `pnpm --filter react-sketch-canvas test:unit -- tests/unit/paths/geometry.spec.ts tests/unit/canvas/svgExport.spec.ts`
- `pnpm lint`
- Pre-commit hook ran `pnpm --filter react-sketch-canvas test:unit` for each commit
