### PR TITLE
fix: stabilize pointer interactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ docs/superpowers/
 .claude/
 .gemini/
 .codex/
+.antigravitycli/
 CLAUDE.md
 GEMINI.md
 CODEX.md

--- a/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasPointerHandlers.ts
+++ b/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasPointerHandlers.ts
@@ -43,6 +43,9 @@ type UseCanvasPointerHandlersReturns = {
 	handlePointerUp: (
 		event: React.PointerEvent<HTMLDivElement> | PointerEvent,
 	) => void;
+	handlePointerCancel: (
+		event: React.PointerEvent<HTMLDivElement> | PointerEvent,
+	) => void;
 };
 
 /**
@@ -97,6 +100,8 @@ export function useCanvasPointerHandlers({
 	onPointerMove,
 	onPointerUp,
 }: UseCanvasPointerHandlersParams): UseCanvasPointerHandlersReturns {
+	const activePointerIdRef = React.useRef<number | null>(null);
+
 	const getCoordinates = useCallback(
 		(pointerEvent: React.PointerEvent<HTMLDivElement>): Point => {
 			const boundingArea = canvasRef.current?.getBoundingClientRect();
@@ -116,12 +121,34 @@ export function useCanvasPointerHandlers({
 		[canvasRef, canvasSizeRef],
 	);
 
+	const isActivePointer = useCallback(
+		(event: React.PointerEvent<HTMLDivElement> | PointerEvent): boolean =>
+			activePointerIdRef.current === event.pointerId,
+		[],
+	);
+
+	const finishActivePointer = useCallback(
+		(event: React.PointerEvent<HTMLDivElement> | PointerEvent): void => {
+			if (!isActivePointer(event)) return;
+
+			activePointerIdRef.current = null;
+			onPointerUp();
+		},
+		[isActivePointer, onPointerUp],
+	);
+
 	const handlePointerDown = useCallback(
 		(event: React.PointerEvent<HTMLDivElement>): void => {
+			if (activePointerIdRef.current !== null) return;
 			if (!isAllowedPointerType(allowOnlyPointerType, event.pointerType))
 				return;
 			if (!shouldHandlePointerButton(event.pointerType, event.button)) return;
 
+			if (event.isTrusted) {
+				event.currentTarget.setPointerCapture(event.pointerId);
+			}
+
+			activePointerIdRef.current = event.pointerId;
 			onPointerDown(
 				getCoordinates(event),
 				isPenEraser(event.pointerType, event.buttons),
@@ -133,35 +160,17 @@ export function useCanvasPointerHandlers({
 	const handlePointerMove = useCallback(
 		(event: React.PointerEvent<HTMLDivElement>): void => {
 			if (!isDrawing) return;
-			if (!isAllowedPointerType(allowOnlyPointerType, event.pointerType))
-				return;
+			if (!isActivePointer(event)) return;
 
 			onPointerMove(getCoordinates(event));
 		},
-		[allowOnlyPointerType, getCoordinates, isDrawing, onPointerMove],
+		[getCoordinates, isActivePointer, isDrawing, onPointerMove],
 	);
-
-	const handlePointerUp = useCallback(
-		(event: React.PointerEvent<HTMLDivElement> | PointerEvent): void => {
-			if (!shouldHandlePointerButton(event.pointerType, event.button)) return;
-			if (!isAllowedPointerType(allowOnlyPointerType, event.pointerType))
-				return;
-
-			onPointerUp();
-		},
-		[allowOnlyPointerType, onPointerUp],
-	);
-
-	React.useEffect(() => {
-		document.addEventListener("pointerup", handlePointerUp);
-		return () => {
-			document.removeEventListener("pointerup", handlePointerUp);
-		};
-	}, [handlePointerUp]);
 
 	return {
 		handlePointerDown,
 		handlePointerMove,
-		handlePointerUp,
+		handlePointerUp: finishActivePointer,
+		handlePointerCancel: finishActivePointer,
 	};
 }

--- a/packages/react-sketch-canvas/src/Canvas/index.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/index.tsx
@@ -66,16 +66,23 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 		preserveBackgroundImageAspectRatio,
 	});
 
-	const { handlePointerDown, handlePointerMove, handlePointerUp } =
-		useCanvasPointerHandlers({
-			canvasRef,
-			canvasSizeRef,
-			isDrawing,
-			allowOnlyPointerType,
-			onPointerDown,
-			onPointerMove,
-			onPointerUp,
-		});
+	const {
+		handlePointerDown,
+		handlePointerMove,
+		handlePointerUp,
+		handlePointerCancel,
+	} = useCanvasPointerHandlers({
+		canvasRef,
+		canvasSizeRef,
+		isDrawing,
+		allowOnlyPointerType,
+		onPointerDown,
+		onPointerMove,
+		onPointerUp,
+	});
+	const acceptsTouchDrawing =
+		allowOnlyPointerType === "all" || allowOnlyPointerType === "touch";
+	const touchAction = acceptsTouchDrawing ? "none" : "pan-x pan-y pinch-zoom";
 
 	const viewBox =
 		withViewBox && canvasSizeRef.current !== null
@@ -88,7 +95,10 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 			ref={canvasRef}
 			className={className}
 			style={{
-				touchAction: "none",
+				touchAction,
+				userSelect: "none",
+				WebkitUserSelect: "none",
+				WebkitTouchCallout: "none",
 				width,
 				height,
 				...style,
@@ -96,6 +106,7 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 			onPointerDown={readOnly ? undefined : handlePointerDown}
 			onPointerMove={readOnly ? undefined : handlePointerMove}
 			onPointerUp={readOnly ? undefined : handlePointerUp}
+			onPointerCancel={readOnly ? undefined : handlePointerCancel}
 		>
 			<CanvasSvg
 				id={id}

--- a/packages/react-sketch-canvas/src/Canvas/types.ts
+++ b/packages/react-sketch-canvas/src/Canvas/types.ts
@@ -155,8 +155,10 @@ export interface CanvasProps {
 	 * Inline styles applied to the outer canvas wrapper.
 	 *
 	 * @remarks
-	 * The component always sets `touchAction: "none"` to keep touch and pen
-	 * drawing from scrolling the page.
+	 * The component sets `userSelect: "none"` to avoid browser selection
+	 * highlights while drawing. It sets `touchAction: "none"` for touch drawing,
+	 * and `touchAction: "pan-x pan-y pinch-zoom"` in pen-only mode so touch can
+	 * still scroll parent containers.
 	 *
 	 * @defaultValue The package default canvas border style.
 	 */

--- a/packages/react-sketch-canvas/tests/commands.ts
+++ b/packages/react-sketch-canvas/tests/commands.ts
@@ -64,8 +64,10 @@ export async function drawSquare(
 
 	const x = boundingBox.x + originX;
 	const y = boundingBox.y + originY;
+	const pointerId = 1;
 
 	await canvas.dispatchEvent("pointerdown", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: eventButtons,
@@ -76,6 +78,7 @@ export async function drawSquare(
 	});
 
 	await canvas.dispatchEvent("pointermove", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: eventButtons,
@@ -85,6 +88,7 @@ export async function drawSquare(
 		pageY: y + side,
 	});
 	await canvas.dispatchEvent("pointermove", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: eventButtons,
@@ -94,6 +98,7 @@ export async function drawSquare(
 		pageY: y + side,
 	});
 	await canvas.dispatchEvent("pointermove", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: eventButtons,
@@ -103,6 +108,7 @@ export async function drawSquare(
 		pageY: y,
 	});
 	await canvas.dispatchEvent("pointermove", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: eventButtons,
@@ -112,6 +118,7 @@ export async function drawSquare(
 		pageY: y,
 	});
 	await canvas.dispatchEvent("pointerup", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: eventButtons,
@@ -180,8 +187,10 @@ export async function drawLine(
 
 	const x = boundingBox.x + originX;
 	const y = boundingBox.y + originY;
+	const pointerId = 1;
 
 	await canvas.dispatchEvent("pointerdown", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: eventButtons,
@@ -192,6 +201,7 @@ export async function drawLine(
 	});
 
 	await canvas.dispatchEvent("pointermove", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: eventButtons,
@@ -202,6 +212,7 @@ export async function drawLine(
 	});
 
 	await canvas.dispatchEvent("pointerup", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: eventButtons,
@@ -239,8 +250,10 @@ export async function drawEraserLine(
 
 	const x = boundingBox.x + originX;
 	const y = boundingBox.y + originY;
+	const pointerId = 1;
 
 	await canvas.dispatchEvent("pointerdown", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: 32, // Windows surface pen eraser button
@@ -251,6 +264,7 @@ export async function drawEraserLine(
 	});
 
 	await canvas.dispatchEvent("pointermove", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: 32, // Windows surface pen eraser button
@@ -261,6 +275,7 @@ export async function drawEraserLine(
 	});
 
 	await canvas.dispatchEvent("pointerup", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: 32, // Windows surface pen eraser button
@@ -298,8 +313,10 @@ export async function drawPoint(
 
 	const x = boundingBox.x + originX;
 	const y = boundingBox.y + originY;
+	const pointerId = 1;
 
 	await canvas.dispatchEvent("pointerdown", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: eventButtons,
@@ -310,6 +327,7 @@ export async function drawPoint(
 	});
 
 	await canvas.dispatchEvent("pointerup", {
+		pointerId,
 		pointerType,
 		button: eventButton,
 		buttons: eventButtons,

--- a/packages/react-sketch-canvas/tests/events/pointerRelease.spec.tsx
+++ b/packages/react-sketch-canvas/tests/events/pointerRelease.spec.tsx
@@ -3,7 +3,7 @@ import { type CanvasPath, ReactSketchCanvas } from "../../src";
 
 test.use({ viewport: { width: 500, height: 500 } });
 
-test("document pointerup completes an in-progress stroke when the pointer leaves the canvas", async ({
+test("captured canvas pointerup completes an in-progress stroke after leaving the canvas", async ({
 	mount,
 }) => {
 	let paths: CanvasPath[] = [];
@@ -25,6 +25,7 @@ test("document pointerup completes an in-progress stroke when the pointer leaves
 	}
 
 	await canvas.dispatchEvent("pointerdown", {
+		pointerId: 1,
 		pointerType: "pen",
 		button: 0,
 		buttons: 1,
@@ -34,6 +35,7 @@ test("document pointerup completes an in-progress stroke when the pointer leaves
 		pageY: box.y + 10,
 	});
 	await canvas.dispatchEvent("pointermove", {
+		pointerId: 1,
 		pointerType: "pen",
 		button: 0,
 		buttons: 1,
@@ -42,14 +44,11 @@ test("document pointerup completes an in-progress stroke when the pointer leaves
 		pageX: box.x + 40,
 		pageY: box.y + 40,
 	});
-	await component.evaluate(() => {
-		document.dispatchEvent(
-			new PointerEvent("pointerup", {
-				pointerType: "pen",
-				button: 0,
-				buttons: 0,
-			}),
-		);
+	await canvas.dispatchEvent("pointerup", {
+		pointerId: 1,
+		pointerType: "pen",
+		button: 0,
+		buttons: 0,
 	});
 
 	await expect.poll(() => paths.at(0)?.endTimestamp ?? 0).toBeGreaterThan(0);

--- a/packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx
@@ -43,12 +43,15 @@ function Harness({
 				width: 300,
 				height: 200,
 			}) as DOMRect;
+		canvasRef.current.setPointerCapture =
+			canvasRef.current.setPointerCapture ?? vi.fn();
 	}, []);
 
 	return (
 		<div
 			data-testid="canvas"
 			ref={canvasRef}
+			onPointerCancel={handlers.handlePointerCancel}
 			onPointerDown={handlers.handlePointerDown}
 			onPointerMove={handlers.handlePointerMove}
 			onPointerUp={handlers.handlePointerUp}
@@ -95,13 +98,32 @@ describe("useCanvasPointerHandlers", () => {
 			<Harness allowOnlyPointerType="pen" onPointerDown={onPointerDown} />,
 		);
 
-		fireEvent.pointerDown(getByTestId("canvas"), {
+		const event = createEvent.pointerDown(getByTestId("canvas"), {
 			pointerType: "mouse",
 			button: 0,
 			buttons: 1,
 		});
+		fireEvent(getByTestId("canvas"), event);
 
 		expect(onPointerDown).not.toHaveBeenCalled();
+	});
+
+	it("captures accepted pointer input", () => {
+		const { getByTestId } = render(<Harness />);
+		const canvas = getByTestId("canvas");
+		const setPointerCapture = vi.fn();
+		Object.assign(canvas, { setPointerCapture });
+
+		const event = createEvent.pointerDown(canvas, {
+			pointerId: 11,
+			pointerType: "pen",
+			button: 0,
+			buttons: 1,
+		});
+		Object.defineProperty(event, "isTrusted", { value: true });
+		fireEvent(canvas, event);
+
+		expect(setPointerCapture).toHaveBeenCalledWith(11);
 	});
 
 	it("normalizes pointer move while drawing", () => {
@@ -109,8 +131,15 @@ describe("useCanvasPointerHandlers", () => {
 		const { getByTestId } = render(
 			<Harness isDrawing onPointerMove={onPointerMove} />,
 		);
+		fireEvent.pointerDown(getByTestId("canvas"), {
+			pointerId: 4,
+			pointerType: "mouse",
+			button: 0,
+			buttons: 1,
+		});
 
 		const event = createEvent.pointerMove(getByTestId("canvas"), {
+			pointerId: 4,
 			pointerType: "mouse",
 		});
 		Object.defineProperties(event, {
@@ -123,11 +152,133 @@ describe("useCanvasPointerHandlers", () => {
 		expect(onPointerMove).toHaveBeenCalledWith({ x: 32, y: 44 });
 	});
 
-	it("wires document pointerup", () => {
-		const onPointerUp = vi.fn();
-		render(<Harness onPointerUp={onPointerUp} />);
+	it("ignores moves from pointers that are not active", () => {
+		const onPointerMove = vi.fn();
+		const { getByTestId } = render(
+			<Harness isDrawing onPointerMove={onPointerMove} />,
+		);
+		const canvas = getByTestId("canvas");
 
-		fireEvent.pointerUp(document, { pointerType: "mouse", button: 0 });
+		fireEvent.pointerDown(canvas, {
+			pointerId: 1,
+			pointerType: "touch",
+			button: 0,
+			buttons: 1,
+		});
+		fireEvent.pointerDown(canvas, {
+			pointerId: 2,
+			pointerType: "touch",
+			button: 0,
+			buttons: 1,
+		});
+		fireEvent.pointerMove(canvas, {
+			pointerId: 2,
+			pointerType: "touch",
+			pageX: 50,
+			pageY: 80,
+		});
+
+		expect(onPointerMove).not.toHaveBeenCalled();
+	});
+
+	it("finishes the active pointer on canvas pointerup", () => {
+		const onPointerUp = vi.fn();
+		const { getByTestId } = render(<Harness onPointerUp={onPointerUp} />);
+		const canvas = getByTestId("canvas");
+
+		fireEvent.pointerDown(canvas, {
+			pointerId: 1,
+			pointerType: "mouse",
+			button: 0,
+			buttons: 1,
+		});
+
+		fireEvent.pointerUp(canvas, {
+			pointerId: 1,
+			pointerType: "mouse",
+			button: 0,
+		});
+
+		expect(onPointerUp).toHaveBeenCalledOnce();
+	});
+
+	it("finishes the active pointer on canvas pointercancel", () => {
+		const onPointerUp = vi.fn();
+		const { getByTestId } = render(<Harness onPointerUp={onPointerUp} />);
+		const canvas = getByTestId("canvas");
+
+		fireEvent.pointerDown(canvas, {
+			pointerId: 12,
+			pointerType: "pen",
+			button: 0,
+			buttons: 1,
+		});
+		fireEvent.pointerCancel(canvas, {
+			pointerId: 12,
+			pointerType: "pen",
+		});
+
+		expect(onPointerUp).toHaveBeenCalledOnce();
+	});
+
+	it("leaves ignored touch input available for parent scroll in pen-only mode", () => {
+		const onPointerDown = vi.fn();
+		const { getByTestId } = render(
+			<Harness allowOnlyPointerType="pen" onPointerDown={onPointerDown} />,
+		);
+		const event = createEvent.pointerDown(getByTestId("canvas"), {
+			pointerId: 2,
+			pointerType: "touch",
+			button: 0,
+			buttons: 1,
+		});
+
+		fireEvent(getByTestId("canvas"), event);
+
+		expect(onPointerDown).not.toHaveBeenCalled();
+	});
+
+	it("finishes the accepted pointer when the allowed pointer type changes before pointerup", () => {
+		const onPointerUp = vi.fn();
+		const { getByTestId, rerender } = render(
+			<Harness allowOnlyPointerType="all" onPointerUp={onPointerUp} />,
+		);
+		const canvas = getByTestId("canvas");
+
+		fireEvent.pointerDown(canvas, {
+			pointerId: 9,
+			pointerType: "mouse",
+			button: 0,
+			buttons: 1,
+		});
+
+		rerender(<Harness allowOnlyPointerType="pen" onPointerUp={onPointerUp} />);
+
+		fireEvent.pointerUp(canvas, {
+			pointerId: 9,
+			pointerType: "mouse",
+			button: 0,
+		});
+
+		expect(onPointerUp).toHaveBeenCalledOnce();
+	});
+
+	it("finishes the accepted mouse pointer even when pointerup reports no changed button", () => {
+		const onPointerUp = vi.fn();
+		const { getByTestId } = render(<Harness onPointerUp={onPointerUp} />);
+		const canvas = getByTestId("canvas");
+
+		fireEvent.pointerDown(canvas, {
+			pointerId: 10,
+			pointerType: "mouse",
+			button: 0,
+			buttons: 1,
+		});
+		fireEvent.pointerUp(canvas, {
+			pointerId: 10,
+			pointerType: "mouse",
+			button: -1,
+		});
 
 		expect(onPointerUp).toHaveBeenCalledOnce();
 	});

--- a/packages/react-sketch-canvas/tests/unit/react-sketch-canvas.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/react-sketch-canvas.spec.tsx
@@ -15,5 +15,45 @@ describe("ReactSketchCanvas", () => {
 		expect(canvas?.parentElement?.getAttribute("style")).toContain(
 			"height: 180px",
 		);
+		expect(canvas?.parentElement?.getAttribute("style")).toContain(
+			"touch-action: none",
+		);
+		expect(canvas?.parentElement?.getAttribute("style")).toContain(
+			"user-select: none",
+		);
+	});
+
+	it("allows browser panning and zooming for non-pen input in pen-only mode", () => {
+		render(
+			<ReactSketchCanvas
+				id="pen-canvas"
+				width="320px"
+				height="180px"
+				allowOnlyPointerType="pen"
+			/>,
+		);
+
+		const canvas = document.querySelector("svg#pen-canvas");
+
+		expect(canvas?.parentElement?.getAttribute("style")).toContain(
+			"touch-action: pan-x pan-y pinch-zoom",
+		);
+	});
+
+	it("allows browser panning and zooming for touch input in mouse-only mode", () => {
+		render(
+			<ReactSketchCanvas
+				id="mouse-canvas"
+				width="320px"
+				height="180px"
+				allowOnlyPointerType="mouse"
+			/>,
+		);
+
+		const canvas = document.querySelector("svg#mouse-canvas");
+
+		expect(canvas?.parentElement?.getAttribute("style")).toContain(
+			"touch-action: pan-x pan-y pinch-zoom",
+		);
 	});
 });


### PR DESCRIPTION
## Summary

- Stabilize pointer capture by tracking one active pointer and finishing strokes on captured pointerup/pointercancel.
- Prevent stylus/text-selection side effects with canvas selection suppression styles.
- Let touch pan/zoom work in pen-only and mouse-only canvases while preserving touch drawing when touch is accepted.
- Add regression coverage for active pointer filtering, pointer cancel/up completion, touch-action policy, and realistic synthetic pointer ids.

## Issues resolved

Resolves #192
Resolves #181
Resolves #180
Resolves #146
Resolves #128

## Validation

- git diff --check
- pnpm --filter react-sketch-canvas lint
- pnpm --filter react-sketch-canvas test:unit
- pnpm --filter react-sketch-canvas build
- pnpm --filter react-sketch-canvas test:ct
- pnpm --filter react-sketch-canvas test:e2e
