### PR TITLE
v8 pre-release cleanup + close #207 #208

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,30 @@
 ## Prerequisites
 
-[Node.js](http://nodejs.org/) >= 20.x must be installed.
+- [Node.js](http://nodejs.org/) >= 22.13.0
+- [pnpm](https://pnpm.io/) >= 11.0.0
 
 ## Installation
 
-- Install [pnpm](https://pnpm.io/) globally using `npm install -g pnpm`
+- Run `pnpm install` to install all project and workspace dependencies.
 
-- Run `pnpm install` to install the project dependencies.
+## Demo & Documentation Development Server
 
-## Demo Development Server
-
-- Run `pnpm dev` to start the development server.
-- Open `http://localhost:4321/react-sketch-canvas/` in your browser.
+- Run `pnpm dev` to start the docs development server.
+- Open `http://localhost:5173/` in your browser (basename is `/` in development).
 
 ## Running Tests
 
-- Run `pnpm test` to run the tests.
+- Run `pnpm test:unit` to run unit tests (Vitest).
+- Run `pnpm test:ct` to run Playwright component tests.
+- Run `pnpm test:e2e` to run Playwright end-to-end browser tests.
+- Or run `pnpm test` to run all tests sequentially.
+
+## Linting & Formatting
+
+- Run `pnpm lint` to check for linting and formatting issues (Biome).
+- Run `pnpm format` to automatically format the codebase.
 
 ## Building
 
-- Run `pnpm build` to build the project.
+- Run `pnpm build` to compile the library and build the documentation site.
+

--- a/docs/src/content/docs/api/interfaces/canvasprops.md
+++ b/docs/src/content/docs/api/interfaces/canvasprops.md
@@ -334,6 +334,29 @@ Inline styles applied to the internal SVG element.
 
 ***
 
+### touchAction?
+
+> `optional` **touchAction?**: `TouchAction`
+
+Defined in: [Canvas/types.ts:215](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L215)
+
+CSS `touch-action` applied to the canvas wrapper.
+
+#### Remarks
+
+The default is `"none"` when the canvas accepts touch drawing, so single
+finger gestures draw rather than scroll. Override this when you need the
+surrounding page to remain scrollable; for example, set `"pan-y"` to let
+users scroll vertically while still drawing with one finger. The browser
+will start a native pan only when the gesture matches the configured
+axis, so single-finger drawing continues to work.
+
+#### Default Value
+
+`"none"` for touch-drawing modes; `"pan-x pan-y pinch-zoom"` for pen / mouse only modes.
+
+***
+
 ### width
 
 > **width**: `string`

--- a/docs/src/content/docs/api/interfaces/canvasref.md
+++ b/docs/src/content/docs/api/interfaces/canvasref.md
@@ -5,7 +5,7 @@ prev: false
 title: "CanvasRef"
 ---
 
-Defined in: [Canvas/types.ts:209](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L209)
+Defined in: [Canvas/types.ts:223](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L223)
 
 Imperative ref API exposed by the low-level [Canvas](/api/variables/canvas/) component.
 
@@ -19,7 +19,7 @@ Imperative ref API exposed by the low-level [Canvas](/api/variables/canvas/) com
 
 > **exportImage**: (`imageType`, `options?`) => `Promise`\<`string`\>
 
-Defined in: [Canvas/types.ts:221](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L221)
+Defined in: [Canvas/types.ts:235](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L235)
 
 Export the current canvas as a raster image data URL.
 
@@ -54,7 +54,7 @@ depends on the `exportWithBackgroundImage` prop.
 
 > **exportSvg**: () => `Promise`\<`string`\>
 
-Defined in: [Canvas/types.ts:234](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L234)
+Defined in: [Canvas/types.ts:248](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L248)
 
 Export the current canvas as SVG markup.
 

--- a/docs/src/content/docs/api/interfaces/reactsketchcanvasprops.md
+++ b/docs/src/content/docs/api/interfaces/reactsketchcanvasprops.md
@@ -418,6 +418,33 @@ Inline styles applied to the internal SVG element.
 
 ***
 
+### touchAction?
+
+> `optional` **touchAction?**: `TouchAction`
+
+Defined in: [Canvas/types.ts:215](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L215)
+
+CSS `touch-action` applied to the canvas wrapper.
+
+#### Remarks
+
+The default is `"none"` when the canvas accepts touch drawing, so single
+finger gestures draw rather than scroll. Override this when you need the
+surrounding page to remain scrollable; for example, set `"pan-y"` to let
+users scroll vertically while still drawing with one finger. The browser
+will start a native pan only when the gesture matches the configured
+axis, so single-finger drawing continues to work.
+
+#### Default Value
+
+`"none"` for touch-drawing modes; `"pan-x pan-y pinch-zoom"` for pen / mouse only modes.
+
+#### Inherited from
+
+[`CanvasProps`](/api/interfaces/canvasprops/).[`touchAction`](/api/interfaces/canvasprops/#touchaction)
+
+***
+
 ### width?
 
 > `optional` **width?**: `string`

--- a/docs/src/content/docs/api/interfaces/reactsketchcanvasref.md
+++ b/docs/src/content/docs/api/interfaces/reactsketchcanvasref.md
@@ -75,7 +75,7 @@ to normal drawing mode. Existing paths are not changed.
 
 > **exportImage**: (`imageType`, `options?`) => `Promise`\<`string`\>
 
-Defined in: [Canvas/types.ts:221](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L221)
+Defined in: [Canvas/types.ts:235](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L235)
 
 Export the current canvas as a raster image data URL.
 
@@ -134,7 +134,7 @@ The returned paths can be stored and later passed to `loadPaths()`.
 
 > **exportSvg**: () => `Promise`\<`string`\>
 
-Defined in: [Canvas/types.ts:234](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L234)
+Defined in: [Canvas/types.ts:248](https://github.com/vinothpandian/react-sketch-canvas/blob/main/packages/react-sketch-canvas/src/Canvas/types.ts#L248)
 
 Export the current canvas as SVG markup.
 

--- a/docs/src/content/docs/examples/background/meta.json
+++ b/docs/src/content/docs/examples/background/meta.json
@@ -1,4 +1,4 @@
 {
 	"title": "Background",
-	"pages": ["image", "data-uri", "export"]
+	"pages": ["image", "data-uri", "export", "raster-export-quality"]
 }

--- a/docs/src/content/docs/examples/background/raster-export-quality.mdx
+++ b/docs/src/content/docs/examples/background/raster-export-quality.mdx
@@ -1,0 +1,27 @@
+---
+title: Raster export quality
+description: Control raster export resolution with width, height, and pixel ratio.
+---
+
+import ExampleBlock from "../../../../components/ExampleBlock";
+import RasterExportQuality from "../../../../examples/RasterExportQuality";
+import RasterExportQualitySource from "../../../../examples/RasterExportQuality.tsx?raw";
+
+`exportImage()` accepts an optional `{ width, height }` second argument. When you omit it, the library scales the raster output by `window.devicePixelRatio` so the result stays sharp on high-DPI screens. When you pass explicit dimensions, the returned image is exactly that many pixels - which is what you want when generating fixed-size assets (thumbnails, social cards, print previews).
+
+A common pattern for "crisp, fixed logical size" output is to multiply your logical CSS dimensions by a target pixel ratio yourself before passing them in:
+
+```tsx
+const logicalWidth = 640;
+const logicalHeight = 360;
+const pixelRatio = 2;
+
+const dataUrl = await canvasRef.current?.exportImage("png", {
+  width: logicalWidth * pixelRatio,
+  height: logicalHeight * pixelRatio,
+});
+```
+
+<ExampleBlock source={RasterExportQualitySource}>
+  <RasterExportQuality />
+</ExampleBlock>

--- a/docs/src/examples/RasterExportQuality.tsx
+++ b/docs/src/examples/RasterExportQuality.tsx
@@ -1,0 +1,296 @@
+import { type ChangeEvent, useEffect, useRef, useState } from "react";
+import {
+	type CanvasPath,
+	ReactSketchCanvas,
+	type ReactSketchCanvasRef,
+} from "react-sketch-canvas";
+
+const CANVAS_WIDTH = 640;
+const CANVAS_HEIGHT = 360;
+
+const initialPaths: CanvasPath[] = [
+	{
+		drawMode: true,
+		strokeColor: "#0f172a",
+		strokeWidth: 6,
+		paths: [
+			{ x: 60, y: 250 },
+			{ x: 120, y: 130 },
+			{ x: 200, y: 220 },
+			{ x: 280, y: 90 },
+			{ x: 360, y: 200 },
+			{ x: 440, y: 70 },
+			{ x: 540, y: 220 },
+			{ x: 600, y: 130 },
+		],
+	},
+	{
+		drawMode: true,
+		strokeColor: "#ef4444",
+		strokeWidth: 3,
+		paths: [
+			{ x: 90, y: 90 },
+			{ x: 140, y: 95 },
+			{ x: 190, y: 92 },
+		],
+	},
+];
+
+type ExportFormat = "png" | "jpeg";
+
+type ExportResult = {
+	format: ExportFormat;
+	value: string;
+	logicalWidth: number;
+	logicalHeight: number;
+	pixelWidth: number;
+	pixelHeight: number;
+	byteLength: number;
+};
+
+function estimateDataUrlBytes(dataUrl: string): number {
+	const commaIndex = dataUrl.indexOf(",");
+
+	if (commaIndex === -1) return 0;
+
+	const base64 = dataUrl.slice(commaIndex + 1);
+	const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+
+	return Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+export default function App() {
+	const canvasRef = useRef<ReactSketchCanvasRef>(null);
+	const [exportFormat, setExportFormat] = useState<ExportFormat>("png");
+	const [exportWidth, setExportWidth] = useState<number>(CANVAS_WIDTH);
+	const [exportHeight, setExportHeight] = useState<number>(CANVAS_HEIGHT);
+	const [pixelRatio, setPixelRatio] = useState<number>(2);
+	const [useExplicitSize, setUseExplicitSize] = useState<boolean>(true);
+	const [exportResult, setExportResult] = useState<ExportResult | null>(null);
+	const [deviceDpr, setDeviceDpr] = useState<number>(1);
+
+	useEffect(() => {
+		canvasRef.current?.resetCanvas();
+		canvasRef.current?.loadPaths(initialPaths);
+		if (typeof window !== "undefined") {
+			setDeviceDpr(window.devicePixelRatio || 1);
+		}
+	}, []);
+
+	const handleExportFormatChange = (event: ChangeEvent<HTMLSelectElement>) => {
+		setExportFormat(event.target.value as ExportFormat);
+		setExportResult(null);
+	};
+
+	const handleExportWidthChange = (event: ChangeEvent<HTMLInputElement>) => {
+		setExportWidth(Number.parseInt(event.target.value, 10) || 0);
+		setExportResult(null);
+	};
+
+	const handleExportHeightChange = (event: ChangeEvent<HTMLInputElement>) => {
+		setExportHeight(Number.parseInt(event.target.value, 10) || 0);
+		setExportResult(null);
+	};
+
+	const handlePixelRatioChange = (event: ChangeEvent<HTMLSelectElement>) => {
+		setPixelRatio(Number.parseFloat(event.target.value));
+		setExportResult(null);
+	};
+
+	const handleUseExplicitSizeChange = (
+		event: ChangeEvent<HTMLInputElement>,
+	) => {
+		setUseExplicitSize(event.target.checked);
+		setExportResult(null);
+	};
+
+	const handleExportClick = async () => {
+		if (!canvasRef.current) return;
+
+		const logicalWidth = useExplicitSize ? exportWidth : CANVAS_WIDTH;
+		const logicalHeight = useExplicitSize ? exportHeight : CANVAS_HEIGHT;
+		const effectiveRatio = useExplicitSize ? pixelRatio : deviceDpr;
+		const pixelWidth = Math.round(logicalWidth * effectiveRatio);
+		const pixelHeight = Math.round(logicalHeight * effectiveRatio);
+
+		const image = useExplicitSize
+			? await canvasRef.current.exportImage(exportFormat, {
+					width: pixelWidth,
+					height: pixelHeight,
+				})
+			: await canvasRef.current.exportImage(exportFormat);
+
+		setExportResult({
+			format: exportFormat,
+			value: image,
+			logicalWidth,
+			logicalHeight,
+			pixelWidth,
+			pixelHeight,
+			byteLength: estimateDataUrlBytes(image),
+		});
+	};
+
+	const handleClearOutputClick = () => {
+		setExportResult(null);
+	};
+
+	const projectedPixelWidth = useExplicitSize
+		? Math.round(exportWidth * pixelRatio)
+		: Math.round(CANVAS_WIDTH * deviceDpr);
+	const projectedPixelHeight = useExplicitSize
+		? Math.round(exportHeight * pixelRatio)
+		: Math.round(CANVAS_HEIGHT * deviceDpr);
+
+	return (
+		<div className="d-flex flex-column gap-3 p-2">
+			<section>
+				<h1>Export options</h1>
+				<div className="row g-2">
+					<div className="col-md-3">
+						<label htmlFor="rasterExportFormat" className="form-label">
+							Format
+						</label>
+						<select
+							id="rasterExportFormat"
+							className="form-select form-select-sm"
+							value={exportFormat}
+							onChange={handleExportFormatChange}
+						>
+							<option value="png">PNG</option>
+							<option value="jpeg">JPEG</option>
+						</select>
+					</div>
+					<div className="col-md-3">
+						<label htmlFor="rasterExportWidth" className="form-label">
+							Width (CSS px)
+						</label>
+						<input
+							id="rasterExportWidth"
+							className="form-control form-control-sm"
+							type="number"
+							min={1}
+							max={4096}
+							step={20}
+							value={exportWidth}
+							disabled={!useExplicitSize}
+							onChange={handleExportWidthChange}
+						/>
+					</div>
+					<div className="col-md-3">
+						<label htmlFor="rasterExportHeight" className="form-label">
+							Height (CSS px)
+						</label>
+						<input
+							id="rasterExportHeight"
+							className="form-control form-control-sm"
+							type="number"
+							min={1}
+							max={4096}
+							step={20}
+							value={exportHeight}
+							disabled={!useExplicitSize}
+							onChange={handleExportHeightChange}
+						/>
+					</div>
+					<div className="col-md-3">
+						<label htmlFor="rasterExportPixelRatio" className="form-label">
+							Pixel ratio
+						</label>
+						<select
+							id="rasterExportPixelRatio"
+							className="form-select form-select-sm"
+							value={pixelRatio}
+							disabled={!useExplicitSize}
+							onChange={handlePixelRatioChange}
+						>
+							<option value={1}>1x (standard)</option>
+							<option value={2}>2x (retina)</option>
+							<option value={3}>3x (super retina)</option>
+							<option value={4}>4x (print)</option>
+						</select>
+					</div>
+				</div>
+				<div className="form-check mt-3">
+					<input
+						id="rasterExportUseExplicitSize"
+						className="form-check-input"
+						type="checkbox"
+						checked={useExplicitSize}
+						onChange={handleUseExplicitSizeChange}
+					/>
+					<label
+						htmlFor="rasterExportUseExplicitSize"
+						className="form-check-label"
+					>
+						Pass explicit <code>width</code> / <code>height</code> options (when
+						unchecked, the library auto-scales by{" "}
+						<code>window.devicePixelRatio</code> = {deviceDpr.toFixed(2)})
+					</label>
+				</div>
+				<div className="d-flex gap-2 mt-3">
+					<button
+						type="button"
+						className="btn btn-sm btn-primary"
+						onClick={handleExportClick}
+					>
+						Export
+					</button>
+					<button
+						type="button"
+						className="btn btn-sm btn-outline-secondary"
+						onClick={handleClearOutputClick}
+					>
+						Clear output
+					</button>
+				</div>
+				<p className="text-body-secondary small mt-3 mb-0">
+					Projected output:{" "}
+					<strong>
+						{projectedPixelWidth} x {projectedPixelHeight} px
+					</strong>{" "}
+					(logical {useExplicitSize ? exportWidth : CANVAS_WIDTH} x{" "}
+					{useExplicitSize ? exportHeight : CANVAS_HEIGHT} CSS px).
+				</p>
+			</section>
+
+			<section>
+				<h1>Canvas</h1>
+				<ReactSketchCanvas
+					ref={canvasRef}
+					width={`${CANVAS_WIDTH}px`}
+					height={`${CANVAS_HEIGHT}px`}
+					canvasColor="#f8fafc"
+					strokeColor="#0f172a"
+					strokeWidth={6}
+				/>
+			</section>
+
+			{exportResult ? (
+				<section>
+					<h1>Export output</h1>
+					<p className="text-body-secondary small mb-2">
+						{exportResult.format.toUpperCase()} -{" "}
+						<strong>
+							{exportResult.pixelWidth} x {exportResult.pixelHeight} px
+						</strong>{" "}
+						(logical {exportResult.logicalWidth} x {exportResult.logicalHeight}{" "}
+						CSS px), {formatBytes(exportResult.byteLength)} encoded.
+					</p>
+					<img
+						className="img-fluid border rounded"
+						src={exportResult.value}
+						alt={`${exportResult.format.toUpperCase()} export preview`}
+					/>
+				</section>
+			) : null}
+		</div>
+	);
+}

--- a/packages/react-sketch-canvas/package.json
+++ b/packages/react-sketch-canvas/package.json
@@ -26,7 +26,7 @@
 		"CHANGELOG.md"
 	],
 	"engines": {
-		"node": ">=20.0.0"
+		"node": ">=22.13.0"
 	},
 	"size-limit": [
 		{

--- a/packages/react-sketch-canvas/src/Canvas/export/backgroundLayer.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/backgroundLayer.ts
@@ -78,6 +78,17 @@ function isSvgDataUri(url: string): boolean {
 	return /^data:image\/svg\+xml(?:[;,]|$)/i.test(url);
 }
 
+function decodeBase64Utf8(data: string): string {
+	const binary = atob(data);
+	const bytes = new Uint8Array(binary.length);
+
+	for (let i = 0; i < binary.length; i += 1) {
+		bytes[i] = binary.charCodeAt(i);
+	}
+
+	return new TextDecoder("utf-8").decode(bytes);
+}
+
 function decodeSvgDataUri(url: string): string | null {
 	const match = /^data:image\/svg\+xml([^,]*),(.*)$/i.exec(url);
 
@@ -89,7 +100,7 @@ function decodeSvgDataUri(url: string): string | null {
 
 	try {
 		if (metadata.includes(";base64")) {
-			return decodeURIComponent(escape(atob(data)));
+			return decodeBase64Utf8(data);
 		}
 
 		return decodeURIComponent(data);

--- a/packages/react-sketch-canvas/src/Canvas/export/image.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/image.ts
@@ -69,15 +69,42 @@ function prepareStrokeSvgForRasterExport({
 function createRasterCanvas(
 	exportWidth: number,
 	exportHeight: number,
+	pixelRatio: number,
 ): HTMLCanvasElement {
 	const renderCanvas = document.createElement("canvas");
 
-	renderCanvas.width = exportWidth;
-	renderCanvas.height = exportHeight;
+	renderCanvas.width = Math.round(exportWidth * pixelRatio);
+	renderCanvas.height = Math.round(exportHeight * pixelRatio);
 	renderCanvas.style.width = `${exportWidth}px`;
 	renderCanvas.style.height = `${exportHeight}px`;
 
 	return renderCanvas;
+}
+
+/**
+ * Resolve the pixel-density multiplier to use for raster export.
+ *
+ * @remarks
+ * When the caller does not request an explicit export size, the rasterizer
+ * scales by `devicePixelRatio` so the output matches the sharpness of the
+ * on-screen canvas on high-DPI displays. When `options.width` / `options.height`
+ * are supplied, the caller is in charge of the output resolution and we keep a
+ * 1:1 mapping so the produced image is exactly that many pixels.
+ */
+function resolveExportPixelRatio(
+	options: ExportImageOptions | undefined,
+): number {
+	if (options?.width !== undefined || options?.height !== undefined) {
+		return 1;
+	}
+
+	if (typeof window === "undefined") {
+		return 1;
+	}
+
+	const ratio = window.devicePixelRatio;
+
+	return Number.isFinite(ratio) && ratio > 0 ? ratio : 1;
 }
 
 /**
@@ -117,11 +144,20 @@ export async function exportImageFromSvg({
 		exportWithBackgroundImage,
 	});
 	const strokeImage = await loadImage(encodeSvgDataUrl(preparedSvg));
-	const renderCanvas = createRasterCanvas(exportWidth, exportHeight);
+	const pixelRatio = resolveExportPixelRatio(options);
+	const renderCanvas = createRasterCanvas(
+		exportWidth,
+		exportHeight,
+		pixelRatio,
+	);
 	const context = renderCanvas.getContext("2d");
 
 	if (!context) {
 		throw Error("Canvas not rendered yet");
+	}
+
+	if (pixelRatio !== 1) {
+		context.scale(pixelRatio, pixelRatio);
 	}
 
 	const shouldFillCanvasBackground =

--- a/packages/react-sketch-canvas/src/Canvas/export/image.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/image.ts
@@ -50,7 +50,7 @@ function prepareStrokeSvgForRasterExport({
 	exportWithBackgroundImage,
 }: PrepareStrokeSvgForRasterExportParams): SVGElement {
 	if (exportWithBackgroundImage && backgroundImage) {
-		const strokeOnlySvg = removeBackgroundImageFromSvg(svgCanvas, id);
+		const strokeOnlySvg = removeBackgroundImageFromSvg(svgCanvas);
 
 		return prepareSvgForExport(strokeOnlySvg, {
 			id,

--- a/packages/react-sketch-canvas/src/Canvas/export/svg.ts
+++ b/packages/react-sketch-canvas/src/Canvas/export/svg.ts
@@ -91,9 +91,7 @@ function namespaceSvgInternalIds(svgCanvas: SVGElement, id: string): void {
  */
 export function removeBackgroundImageFromSvg(
 	svgCanvas: SVGElement,
-	id: string,
 ): SVGElement {
-	void id;
 	queryInternalElement(svgCanvas, "background")?.remove();
 	queryInternalElement(svgCanvas, "canvas-background-group")?.remove();
 	queryInternalElement(svgCanvas, "canvas-background")?.remove();

--- a/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasPointerHandlers.ts
+++ b/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasPointerHandlers.ts
@@ -139,10 +139,19 @@ export function useCanvasPointerHandlers({
 
 	const handlePointerDown = useCallback(
 		(event: React.PointerEvent<HTMLDivElement>): void => {
-			if (activePointerIdRef.current !== null) return;
 			if (!isAllowedPointerType(allowOnlyPointerType, event.pointerType))
 				return;
 			if (!shouldHandlePointerButton(event.pointerType, event.button)) return;
+
+			if (activePointerIdRef.current !== null) {
+				// A second pointer arrived mid-stroke (e.g. user moved from a single
+				// finger to a two-finger gesture). End the active stroke so the
+				// browser is free to interpret the gesture as a pan/zoom and so a
+				// stale stroke does not record movement from the wrong pointer.
+				activePointerIdRef.current = null;
+				onPointerUp();
+				return;
+			}
 
 			preventNativeTouchScroll(event);
 
@@ -160,6 +169,7 @@ export function useCanvasPointerHandlers({
 			allowOnlyPointerType,
 			getCoordinates,
 			onPointerDown,
+			onPointerUp,
 			preventNativeTouchScroll,
 		],
 	);

--- a/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasPointerHandlers.ts
+++ b/packages/react-sketch-canvas/src/Canvas/hooks/useCanvasPointerHandlers.ts
@@ -34,10 +34,12 @@ type UseCanvasPointerHandlersParams = Pick<
 type UseCanvasPointerHandlersReturns = {
 	handlePointerDown: (event: React.PointerEvent<HTMLDivElement>) => void;
 	handlePointerMove: (event: React.PointerEvent<HTMLDivElement>) => void;
-	handlePointerUp: (
-		event: React.PointerEvent<HTMLDivElement> | PointerEvent,
-	) => void;
-	handlePointerCancel: (
+	/**
+	 * Bound to both `onPointerUp` and `onPointerCancel`: in either case the
+	 * active stroke ends, since the pointer is no longer guaranteed to deliver
+	 * further move events.
+	 */
+	finishActivePointer: (
 		event: React.PointerEvent<HTMLDivElement> | PointerEvent,
 	) => void;
 };
@@ -182,7 +184,6 @@ export function useCanvasPointerHandlers({
 	return {
 		handlePointerDown,
 		handlePointerMove,
-		handlePointerUp: finishActivePointer,
-		handlePointerCancel: finishActivePointer,
+		finishActivePointer,
 	};
 }

--- a/packages/react-sketch-canvas/src/Canvas/index.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/index.tsx
@@ -44,6 +44,7 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 		svgStyle = {},
 		withViewBox = false,
 		readOnly = false,
+		touchAction: touchActionProp,
 	} = props;
 
 	const canvasRef = React.useRef<HTMLDivElement>(null);
@@ -106,7 +107,9 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 		});
 	const acceptsTouchDrawing =
 		allowOnlyPointerType === "all" || allowOnlyPointerType === "touch";
-	const touchAction = acceptsTouchDrawing ? "none" : "pan-x pan-y pinch-zoom";
+	const touchAction =
+		touchActionProp ??
+		(acceptsTouchDrawing ? "none" : "pan-x pan-y pinch-zoom");
 
 	const viewBox =
 		withViewBox && canvasSize !== null

--- a/packages/react-sketch-canvas/src/Canvas/index.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/index.tsx
@@ -95,19 +95,15 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 		preserveBackgroundImageAspectRatio,
 	});
 
-	const {
-		handlePointerDown,
-		handlePointerMove,
-		handlePointerUp,
-		handlePointerCancel,
-	} = useCanvasPointerHandlers({
-		canvasRef,
-		isDrawing,
-		allowOnlyPointerType,
-		onPointerDown,
-		onPointerMove,
-		onPointerUp,
-	});
+	const { handlePointerDown, handlePointerMove, finishActivePointer } =
+		useCanvasPointerHandlers({
+			canvasRef,
+			isDrawing,
+			allowOnlyPointerType,
+			onPointerDown,
+			onPointerMove,
+			onPointerUp,
+		});
 	const acceptsTouchDrawing =
 		allowOnlyPointerType === "all" || allowOnlyPointerType === "touch";
 	const touchAction = acceptsTouchDrawing ? "none" : "pan-x pan-y pinch-zoom";
@@ -133,8 +129,8 @@ export const Canvas = React.forwardRef<CanvasRef, CanvasProps>((props, ref) => {
 			}}
 			onPointerDown={readOnly ? undefined : handlePointerDown}
 			onPointerMove={readOnly ? undefined : handlePointerMove}
-			onPointerUp={readOnly ? undefined : handlePointerUp}
-			onPointerCancel={readOnly ? undefined : handlePointerCancel}
+			onPointerUp={readOnly ? undefined : finishActivePointer}
+			onPointerCancel={readOnly ? undefined : finishActivePointer}
 		>
 			<CanvasSvg
 				id={id}

--- a/packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx
+++ b/packages/react-sketch-canvas/src/Canvas/svg/EraserMasks.tsx
@@ -1,5 +1,6 @@
 import type * as React from "react";
 import { SvgPath } from "../../Paths";
+import { ERASER_MASK_STROKE_COLOR } from "../../ReactSketchCanvas/constants";
 import type { CanvasPath } from "../../types";
 
 type EraserMasksProps = {
@@ -35,7 +36,7 @@ export function HiddenEraserStrokes({
 					key={`${internalId}__eraser-${i}`}
 					id={`${internalId}__eraser-${i}`}
 					paths={eraserPath.paths}
-					strokeColor="#000"
+					strokeColor={ERASER_MASK_STROKE_COLOR}
 					strokeWidth={eraserPath.strokeWidth}
 				/>
 			))}

--- a/packages/react-sketch-canvas/src/Canvas/types.ts
+++ b/packages/react-sketch-canvas/src/Canvas/types.ts
@@ -199,6 +199,20 @@ export interface CanvasProps {
 	 * @defaultValue false
 	 */
 	readOnly?: boolean;
+	/**
+	 * CSS `touch-action` applied to the canvas wrapper.
+	 *
+	 * @remarks
+	 * The default is `"none"` when the canvas accepts touch drawing, so single
+	 * finger gestures draw rather than scroll. Override this when you need the
+	 * surrounding page to remain scrollable; for example, set `"pan-y"` to let
+	 * users scroll vertically while still drawing with one finger. The browser
+	 * will start a native pan only when the gesture matches the configured
+	 * axis, so single-finger drawing continues to work.
+	 *
+	 * @defaultValue `"none"` for touch-drawing modes; `"pan-x pan-y pinch-zoom"` for pen / mouse only modes.
+	 */
+	touchAction?: React.CSSProperties["touchAction"];
 }
 
 /**

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/constants.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Internal stroke color used for mask-mode eraser paths.
+ *
+ * @remarks
+ * The eraser is rendered onto a white SVG mask backdrop; a solid black stroke
+ * is what cuts holes through the mask. The value is shared by stroke creation
+ * (`state/strokes.ts`) and the hidden mask SVG (`Canvas/svg/EraserMasks.tsx`)
+ * so they cannot drift apart.
+ */
+export const ERASER_MASK_STROKE_COLOR = "#000000";

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/hooks/useSketchCanvasController.ts
@@ -35,7 +35,6 @@ type UseSketchCanvasControllerParams = Required<
 type UseSketchCanvasControllerReturns = {
 	currentPaths: CanvasPath[];
 	isDrawing: boolean;
-	drawMode: boolean;
 	setEraseMode: (erase: boolean) => void;
 	undo: () => void;
 	redo: () => void;
@@ -294,7 +293,6 @@ export function useSketchCanvasController({
 	return {
 		currentPaths,
 		isDrawing,
-		drawMode: state.drawMode,
 		setEraseMode,
 		undo,
 		redo,

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/index.tsx
@@ -51,6 +51,7 @@ export const ReactSketchCanvas = React.forwardRef<
 		withTimestamp = false,
 		withViewBox = false,
 		readOnly = false,
+		touchAction,
 	} = props;
 
 	const svgCanvas = React.useRef<CanvasRef>(null);
@@ -109,6 +110,7 @@ export const ReactSketchCanvas = React.forwardRef<
 			onPointerUp={handlePointerUp}
 			withViewBox={withViewBox}
 			readOnly={readOnly}
+			touchAction={touchAction}
 		/>
 	);
 });

--- a/packages/react-sketch-canvas/src/ReactSketchCanvas/state/strokes.ts
+++ b/packages/react-sketch-canvas/src/ReactSketchCanvas/state/strokes.ts
@@ -1,4 +1,5 @@
 import type { CanvasPath, Point } from "../../types";
+import { ERASER_MASK_STROKE_COLOR } from "../constants";
 
 type CreateStrokeParams = {
 	point: Point;
@@ -30,7 +31,7 @@ export function createStroke({
 }: CreateStrokeParams): CreateStrokeReturns {
 	const stroke: CanvasPath = {
 		drawMode,
-		strokeColor: drawMode ? strokeColor : "#000000",
+		strokeColor: drawMode ? strokeColor : ERASER_MASK_STROKE_COLOR,
 		strokeWidth: drawMode ? strokeWidth : eraserWidth,
 		paths: [point],
 	};

--- a/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
+++ b/packages/react-sketch-canvas/tests/unit/canvas/imageExport.spec.ts
@@ -128,7 +128,7 @@ describe("exportImageFromSvg", () => {
 		});
 	});
 
-	it("uses rendered SVG dimensions for default raster export size", async () => {
+	it("scales raster export by devicePixelRatio while preserving CSS size", async () => {
 		Object.defineProperty(window, "devicePixelRatio", {
 			configurable: true,
 			value: 2,
@@ -149,10 +149,40 @@ describe("exportImageFromSvg", () => {
 		const canvas = vi.mocked(HTMLCanvasElement.prototype.toDataURL).mock
 			.contexts[0] as HTMLCanvasElement;
 
-		expect(canvas.width).toBe(320);
-		expect(canvas.height).toBe(180);
+		expect(canvas.width).toBe(640);
+		expect(canvas.height).toBe(360);
 		expect(canvas.style.width).toBe("320px");
 		expect(canvas.style.height).toBe("180px");
+		expect(scale).toHaveBeenCalledWith(2, 2);
+	});
+
+	it("uses the requested pixel dimensions when options are provided and skips DPR scaling", async () => {
+		Object.defineProperty(window, "devicePixelRatio", {
+			configurable: true,
+			value: 3,
+		});
+		const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+
+		await exportImageFromSvg({
+			id: "canvas",
+			svgCanvas: svg,
+			svgWidth: 320,
+			svgHeight: 180,
+			imageType: "png",
+			canvasColor: "white",
+			backgroundImage: "",
+			exportWithBackgroundImage: false,
+			options: { width: 800, height: 600 },
+		});
+
+		const canvas = vi.mocked(HTMLCanvasElement.prototype.toDataURL).mock
+			.contexts[0] as HTMLCanvasElement;
+
+		expect(canvas.width).toBe(800);
+		expect(canvas.height).toBe(600);
+		expect(canvas.style.width).toBe("800px");
+		expect(canvas.style.height).toBe("600px");
+		expect(scale).not.toHaveBeenCalled();
 	});
 
 	it("removes background-image markup from the serialized SVG when exporting without the background image", async () => {

--- a/packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx
@@ -357,4 +357,65 @@ describe("useCanvasPointerHandlers", () => {
 
 		expect(onPointerUp).toHaveBeenCalledOnce();
 	});
+
+	it("aborts the active stroke when a second pointer arrives mid-gesture", () => {
+		const onPointerDown = vi.fn();
+		const onPointerUp = vi.fn();
+		const { getByTestId } = render(
+			<Harness onPointerDown={onPointerDown} onPointerUp={onPointerUp} />,
+		);
+		const canvas = getByTestId("canvas");
+
+		fireEvent.pointerDown(canvas, {
+			pointerId: 1,
+			pointerType: "touch",
+			button: 0,
+			buttons: 1,
+		});
+		fireEvent.pointerDown(canvas, {
+			pointerId: 2,
+			pointerType: "touch",
+			button: 0,
+			buttons: 1,
+		});
+
+		expect(onPointerDown).toHaveBeenCalledOnce();
+		expect(onPointerUp).toHaveBeenCalledOnce();
+	});
+
+	it("ignores subsequent move events from either pointer after a multi-touch abort", () => {
+		const onPointerMove = vi.fn();
+		const { getByTestId, rerender } = render(<Harness isDrawing={true} />);
+		const canvas = getByTestId("canvas");
+
+		fireEvent.pointerDown(canvas, {
+			pointerId: 1,
+			pointerType: "touch",
+			button: 0,
+			buttons: 1,
+		});
+		fireEvent.pointerDown(canvas, {
+			pointerId: 2,
+			pointerType: "touch",
+			button: 0,
+			buttons: 1,
+		});
+
+		rerender(<Harness isDrawing={true} onPointerMove={onPointerMove} />);
+
+		fireEvent.pointerMove(canvas, {
+			pointerId: 1,
+			pointerType: "touch",
+			pageX: 50,
+			pageY: 50,
+		});
+		fireEvent.pointerMove(canvas, {
+			pointerId: 2,
+			pointerType: "touch",
+			pageX: 60,
+			pageY: 60,
+		});
+
+		expect(onPointerMove).not.toHaveBeenCalled();
+	});
 });

--- a/packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx
+++ b/packages/react-sketch-canvas/tests/unit/canvas/useCanvasPointerHandlers.spec.tsx
@@ -47,10 +47,10 @@ function Harness({
 		<div
 			data-testid="canvas"
 			ref={canvasRef}
-			onPointerCancel={handlers.handlePointerCancel}
+			onPointerCancel={handlers.finishActivePointer}
 			onPointerDown={handlers.handlePointerDown}
 			onPointerMove={handlers.handlePointerMove}
-			onPointerUp={handlers.handlePointerUp}
+			onPointerUp={handlers.finishActivePointer}
 		/>
 	);
 }


### PR DESCRIPTION
Pre-release pass on the v8 branch. Splits into two commits:

## Commit 1 — quality cleanup (`a9a10a6`)

- Align `engines.node` to `>=22.13.0` in the library package so it matches the repo root.
- Refresh `CLAUDE.md` and `CONTRIBUTING.md`: correct state-slice layout (only three slices), updated commands and dev-server URL.
- Drop unused `id` argument from `removeBackgroundImageFromSvg`.
- Drop unused `drawMode` return from `useSketchCanvasController`.
- Collapse duplicated `handlePointerUp` / `handlePointerCancel` return values into a single `finishActivePointer`, bound to both DOM events at the call site so the intent reads at a glance.
- Centralize the eraser mask stroke color (`ERASER_MASK_STROKE_COLOR`) in a new `ReactSketchCanvas/constants.ts` shared by `state/strokes.ts` and `Canvas/svg/EraserMasks.tsx`.
- Replace deprecated `escape` / `atob` in `Canvas/export/backgroundLayer.ts` with a `TextDecoder`-based UTF-8 base64 decoder.

## Commit 2 — close #207 and #208 (`95190e8`)

### Closes #207 — high-DPI raster export

`exportImage()` now scales the raster output by `window.devicePixelRatio` when the caller does not pass `options.width` / `options.height`. CSS size stays unchanged, so the data URL just gains the extra pixels that produce crisp edges on hi-DPI displays. Explicit options still produce the exact pixel count requested (caller owns the resolution there).

Implemented in `Canvas/export/image.ts`:
- `resolveExportPixelRatio()` selects DPR (default) vs. 1 (explicit options).
- `createRasterCanvas()` multiplies pixel dimensions by the ratio while keeping CSS width/height in logical pixels.
- `context.scale(dpr, dpr)` is applied once so existing draw calls (background + strokes) remain in logical-pixel space.

### Closes #208 — two-finger / parent-container touch gestures

1. `useCanvasPointerHandlers.handlePointerDown` now aborts the active stroke when a second pointer arrives mid-gesture. This kills the zig-zag drawing reported in #146 / #128 and lets the browser interpret the rest of the gesture as a pan / pinch.
2. New optional `touchAction` prop on `CanvasProps` / `ReactSketchCanvasProps`. Defaults to the previous behavior (`"none"` for touch-drawing modes, `"pan-x pan-y pinch-zoom"` otherwise). Consumers can pass e.g. `"pan-y"` so the page scrolls while single-finger drawing keeps working.

## Tests

- `tests/unit/canvas/imageExport.spec.ts`: replaces the "default size" case with explicit DPR-aware coverage; adds a case proving explicit options skip DPR scaling.
- `tests/unit/canvas/useCanvasPointerHandlers.spec.tsx`: covers multi-touch abort (active stroke finishes when a second pointer goes down; subsequent moves from either pointer are ignored).
- All other suites unchanged.

## Verification

- `pnpm lint` clean (129 files).
- `pnpm test:unit` 82/82 pass (also re-run by lefthook pre-commit on both commits).
- `pnpm --filter react-sketch-canvas build` green (tsup CJS/ESM/DTS).

## Notes

- Changesets and `.changeset/pre.json` are intentionally untouched. The release / pre-mode exit will happen after this branch is merged.
- Remaining follow-up issues left open for later: #209 (DarkReader), #210 (LINE in-app browser), #211 (Apple Pencil mid-stroke drop), #212 (`withViewBox` should fit loaded paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)